### PR TITLE
External links order and format cleanup

### DIFF
--- a/docs/library/2048.md
+++ b/docs/library/2048.md
@@ -75,5 +75,5 @@ This core does not have specific compatiblity issues
 ## External Links
 
 * [Libretro Repository](https://github.com/libretro/libretro-2048)
-* [Report Issues Here](https://github.com/libretro/libretro-2048/issues)
+* [Report Issues Here](http://github.com/libretro/libretro-meta/issues)
 * [Official Website](http://gabrielecirulli.github.io/2048/)

--- a/docs/library/2048.md
+++ b/docs/library/2048.md
@@ -75,5 +75,5 @@ This core does not have specific compatiblity issues
 ## External Links
 
 * [Libretro Repository](https://github.com/libretro/libretro-2048)
-* [Report Issues Here](http://github.com/libretro/libretro-meta/issues)
+* [Report Issues Here](https://github.com/libretro/libretro-meta/issues)
 * [Official Website](http://gabrielecirulli.github.io/2048/)

--- a/docs/library/4DO.md
+++ b/docs/library/4DO.md
@@ -38,7 +38,7 @@ These are libretro features, not frontend or standalone emulator features.
 
 ## Options
 
-This core has a few options that can be tweaked from the core options menu. The default setting is bolded. 
+This core has a few options that can be tweaked from the core options menu. The default setting is bolded.
 
 - **High Resolution (restart)** (**Off**/On): Doubles internal resolution.
 
@@ -75,5 +75,5 @@ The core supports one controller setting(s):
 ## External Links
 
 * [Libretro Repository](https://github.com/libretro/4do-libretro)
-* [Report Issues Here](https://github.com/libretro/4do-libretro/issues)
+* [Report Issues Here](http://github.com/libretro/libretro-meta/issues)
 * [Official Website](http://www.fourdo.com/)

--- a/docs/library/4DO.md
+++ b/docs/library/4DO.md
@@ -75,5 +75,5 @@ The core supports one controller setting(s):
 ## External Links
 
 * [Libretro Repository](https://github.com/libretro/4do-libretro)
-* [Report Issues Here](http://github.com/libretro/libretro-meta/issues)
+* [Report Issues Here](https://github.com/libretro/libretro-meta/issues)
 * [Official Website](http://www.fourdo.com/)

--- a/docs/library/Core_Template.md
+++ b/docs/library/Core_Template.md
@@ -6,7 +6,9 @@ Author(s):
 
 ## Contribute to this documentation
 
-In order to propose improvements to this document, [visit it's corresponding source page on github](https://github.com/libretro/docs/tree/master/docs/library). Changes are proposed using "Pull Requests."
+In order to propose improvements to this document, [visit it's corresponding source page on github](https://github.com/libretro/docs/tree/master/docs/library/). Changes are proposed using "Pull Requests."
+
+(add relevent corenamed.md to end of link)
 
 ## License
 
@@ -40,7 +42,7 @@ These are libretro features, not frontend or standalone emulator features.
 
 ## Options
 
-This core has a few options that can be tweaked from the core options menu. The default setting is bolded. 
+This core has a few options that can be tweaked from the core options menu. The default setting is bolded.
 
 - **Core Option** (**Setting1**/Setting2): Description.
 

--- a/docs/library/Core_Template.md
+++ b/docs/library/Core_Template.md
@@ -82,6 +82,6 @@ This core does not have specific compatiblity issues
 
 ## External Links
 
-* [Libretro Repository](http://link)
-* [Report Issues Here](http://github.com/libretro/libretro-meta/issues)
-* [Official Website](http://link)  
+* [Libretro Repository](https://link)
+* [Report Issues Here](https://github.com/libretro/libretro-meta/issues)
+* [Official Website](https://link)  

--- a/docs/library/Stella.md
+++ b/docs/library/Stella.md
@@ -71,5 +71,5 @@ This core does not have specific compatiblity issues
 ## External Links
 
 * [Libretro Repository](https://github.com/libretro/stella-libretro)
-* [Report Issues Here](https://github.com/libretro/stella-libretro/issues)
+* [Report Issues Here](http://github.com/libretro/libretro-meta/issues)
 * [Official Website](https://stella-emu.github.io/)

--- a/docs/library/Stella.md
+++ b/docs/library/Stella.md
@@ -71,5 +71,5 @@ This core does not have specific compatiblity issues
 ## External Links
 
 * [Libretro Repository](https://github.com/libretro/stella-libretro)
-* [Report Issues Here](http://github.com/libretro/libretro-meta/issues)
+* [Report Issues Here](https://github.com/libretro/libretro-meta/issues)
 * [Official Website](https://stella-emu.github.io/)

--- a/docs/library/Yabause.md
+++ b/docs/library/Yabause.md
@@ -73,6 +73,6 @@ The core supports controller setting:
 ## External Links
 
 * [Libretro Repository](https://github.com/libretro/4do-libretro)
-* [Report Issues Here](http://github.com/libretro/libretro-meta/issues)
+* [Report Issues Here](https://github.com/libretro/libretro-meta/issues)
 * [Official Website](https://yabause.org/)
 * [Official GitHub Repository](https://github.com/Guillaumito/yabause)

--- a/docs/library/Yabause.md
+++ b/docs/library/Yabause.md
@@ -72,6 +72,7 @@ The core supports controller setting:
 
 ## External Links
 
+* [Libretro Repository](https://github.com/libretro/4do-libretro)
+* [Report Issues Here](http://github.com/libretro/libretro-meta/issues)
 * [Official Website](https://yabause.org/)
 * [Official GitHub Repository](https://github.com/Guillaumito/yabause)
-* [Libretro Repository](https://github.com/libretro/4do-libretro)

--- a/docs/library/emux_gb.md
+++ b/docs/library/emux_gb.md
@@ -72,6 +72,6 @@ untested
 
 ## External Links
 
-* [Official Repository](https://github.com/sronsse/emux)  
 * [Libretro Repository](https://github.com/libretro/emux)
 * [Report Issues Here](http://github.com/libretro/libretro-meta/issues)
+* [Official Repository](https://github.com/sronsse/emux) 

--- a/docs/library/emux_gb.md
+++ b/docs/library/emux_gb.md
@@ -73,5 +73,5 @@ untested
 ## External Links
 
 * [Libretro Repository](https://github.com/libretro/emux)
-* [Report Issues Here](http://github.com/libretro/libretro-meta/issues)
-* [Official Repository](https://github.com/sronsse/emux) 
+* [Report Issues Here](https://github.com/libretro/libretro-meta/issues)
+* [Official Repository](https://github.com/sronsse/emux)

--- a/docs/library/gambatte.md
+++ b/docs/library/gambatte.md
@@ -92,6 +92,7 @@ The core supports controller setting:
 
 ## External Links
 
-* [Official Website](https://sourceforge.net/projects/gambatte/)  
+
 * [Libretro Repository](https://github.com/libretro/gambatte-libretro)
 * [Report Issues Here](https://github.com/libretro/libretro-meta)
+* [Official Website](https://sourceforge.net/projects/gambatte/)  

--- a/docs/library/genesis_plus_gx.md
+++ b/docs/library/genesis_plus_gx.md
@@ -4,7 +4,7 @@
 
 Genesis Plus GX is an open-source Sega 8/16 bit emulator focused on accuracy and portability. The source code, originally based on Genesis Plus 1.3 by Charles MacDonald, has been heavily modified & enhanced, with respect to initial goals and design, in order to improve the accuracy of emulation, implementing new features and adding support for extra peripherals, cartridge & systems hardware.
 
-Author(s): Charles McDonald|Eke-Eke 
+Author(s): Charles McDonald|Eke-Eke
 
 ## Contribute to this documentation
 
@@ -135,5 +135,5 @@ The Genesis Plus GX core supports sixteen different controller settings:
 ## External Links
 
 * [Libretro Repository](https://github.com/libretro/Genesis-Plus-GX)
-* [Report Issues Here](https://github.com/libretro/Genesis-Plus-GX/issues)
+* [Report Issues Here](http://github.com/libretro/libretro-meta/issues)
 * [Official Website](https://github.com/ekeeke/Genesis-Plus-GX)

--- a/docs/library/genesis_plus_gx.md
+++ b/docs/library/genesis_plus_gx.md
@@ -135,5 +135,5 @@ The Genesis Plus GX core supports sixteen different controller settings:
 ## External Links
 
 * [Libretro Repository](https://github.com/libretro/Genesis-Plus-GX)
-* [Report Issues Here](http://github.com/libretro/libretro-meta/issues)
+* [Report Issues Here](https://github.com/libretro/libretro-meta/issues)
 * [Official Website](https://github.com/ekeeke/Genesis-Plus-GX)

--- a/docs/library/gpsp.md
+++ b/docs/library/gpsp.md
@@ -102,4 +102,4 @@ Note: Shoulder buttons are not supported
 ## External Links
 
 * [Libretro Repository](https://github.com/libretro/gpsp)
-* [Report Issues Here](http://github.com/libretro/libretro-meta/issues)
+* [Report Issues Here](https://github.com/libretro/libretro-meta/issues)

--- a/docs/library/gpsp.md
+++ b/docs/library/gpsp.md
@@ -102,3 +102,4 @@ Note: Shoulder buttons are not supported
 ## External Links
 
 * [Libretro Repository](https://github.com/libretro/gpsp)
+* [Report Issues Here](http://github.com/libretro/libretro-meta/issues)

--- a/docs/library/handy.md
+++ b/docs/library/handy.md
@@ -81,5 +81,5 @@ Supported combinations
 ## External Links
 
 * [Libretro Repository](https://github.com/libretro/libretro-handy)
-* [Report Issues Here](http://github.com/libretro/libretro-meta/issues)
+* [Report Issues Here](https://github.com/libretro/libretro-meta/issues)
 * [Official Website](http://handy.sourceforge.net/)

--- a/docs/library/handy.md
+++ b/docs/library/handy.md
@@ -79,7 +79,7 @@ Supported combinations
 [Handy Compatibility List](https://wiki.libretro.com/index.php?title=Atari_Lynx_Core_Compatibility)
 
 ## External Links
- 
+
 * [Libretro Repository](https://github.com/libretro/libretro-handy)
-* [Report Issues Here](https://github.com/libretro/libretro-handy/issues)
-* [Official Website](http://handy.sourceforge.net/) 
+* [Report Issues Here](http://github.com/libretro/libretro-meta/issues)
+* [Official Website](http://handy.sourceforge.net/)

--- a/docs/library/hatari.md
+++ b/docs/library/hatari.md
@@ -76,6 +76,6 @@ untested
 ## External Links
 
 * [Libretro Repository](https://github.com/libretro/hatari)
-* [Report Issues Here](http://github.com/libretro/libretro-meta/issues)
+* [Report Issues Here](https://github.com/libretro/libretro-meta/issues)
 * [Official Website](http://hatari.tuxfamily.org/)  
 * [Official Mercurial Repository](http://hg.tuxfamily.org/mercurialroot/hatari/hatari)

--- a/docs/library/hatari.md
+++ b/docs/library/hatari.md
@@ -75,7 +75,7 @@ untested
 
 ## External Links
 
-* [Official Website](http://hatari.tuxfamily.org/)  
-* [Official Mercurial Repository](http://hg.tuxfamily.org/mercurialroot/hatari/hatari)
 * [Libretro Repository](https://github.com/libretro/hatari)
 * [Report Issues Here](http://github.com/libretro/libretro-meta/issues)
+* [Official Website](http://hatari.tuxfamily.org/)  
+* [Official Mercurial Repository](http://hg.tuxfamily.org/mercurialroot/hatari/hatari)

--- a/docs/library/mame2003.md
+++ b/docs/library/mame2003.md
@@ -10,7 +10,7 @@ See also: MAME 2000, MAME 2010, MAME 2014, MAME 2016, and MAME.
 
 ## Contribute to this documentation
 
-In order to propose improvements to this document, [visit it's corresponding source page on github](https://github.com/libretro/docs/blob/master/docs/library/mame2003.md). Changes are proposed using "Pull Requests." 
+In order to propose improvements to this document, [visit it's corresponding source page on github](https://github.com/libretro/docs/blob/master/docs/library/mame2003.md). Changes are proposed using "Pull Requests."
 
 ## ROMset compatibility with MAME 2003
 
@@ -165,7 +165,8 @@ mame2003-rstick_to_btns = "enabled"
 
 ## External Links
 
-* [Official Website](http://mamedev.org/)  
+
 * [Libretro Repository](https://github.com/libretro/mame2003-libretro)
-* [RetroPie MAME 2003 documentation](https://github.com/RetroPie/RetroPie-Setup/wiki/lr-mame2003)
 * [Report Issues Here](http://github.com/libretro/libretro-meta/issues)
+* [RetroPie MAME 2003 documentation](https://github.com/RetroPie/RetroPie-Setup/wiki/lr-mame2003)
+* [Official Website](http://mamedev.org/)  

--- a/docs/library/mame2003.md
+++ b/docs/library/mame2003.md
@@ -167,6 +167,6 @@ mame2003-rstick_to_btns = "enabled"
 
 
 * [Libretro Repository](https://github.com/libretro/mame2003-libretro)
-* [Report Issues Here](http://github.com/libretro/libretro-meta/issues)
+* [Report Issues Here](https://github.com/libretro/libretro-meta/issues)
 * [RetroPie MAME 2003 documentation](https://github.com/RetroPie/RetroPie-Setup/wiki/lr-mame2003)
 * [Official Website](http://mamedev.org/)  

--- a/docs/library/mednafen_gba.md
+++ b/docs/library/mednafen_gba.md
@@ -75,6 +75,7 @@ TBC
 
 ## External Links
 
-* [Official Website](http://mednafen.sourceforge.net/)  
+
 * [Libretro Repository](https://github.com/libretro/beetle-gba-libretro)
 * [Report Issues Here](http://github.com/libretro/libretro-meta/issues)
+* [Official Website](http://mednafen.sourceforge.net/)  

--- a/docs/library/mednafen_gba.md
+++ b/docs/library/mednafen_gba.md
@@ -77,5 +77,5 @@ TBC
 
 
 * [Libretro Repository](https://github.com/libretro/beetle-gba-libretro)
-* [Report Issues Here](http://github.com/libretro/libretro-meta/issues)
+* [Report Issues Here](https://github.com/libretro/libretro-meta/issues)
 * [Official Website](http://mednafen.sourceforge.net/)  

--- a/docs/library/mednafen_lynx.md
+++ b/docs/library/mednafen_lynx.md
@@ -79,7 +79,7 @@ Supported combinations
 [Beetle Handy Compatibility List](https://wiki.libretro.com/index.php?title=Atari_Lynx_Core_Compatibility)
 
 ## External Links
- 
+
 * [Libretro Repository](https://github.com/libretro/beetle-lynx-libretro)
-* [Report Issues Here](https://github.com/libretro/beetle-lynx-libretro/ssues)
-* [Official Website](http://mednafen.sourceforge.net/) 
+* [Report Issues Here](http://github.com/libretro/libretro-meta/issues)
+* [Official Website](http://mednafen.sourceforge.net/)

--- a/docs/library/mednafen_lynx.md
+++ b/docs/library/mednafen_lynx.md
@@ -81,5 +81,5 @@ Supported combinations
 ## External Links
 
 * [Libretro Repository](https://github.com/libretro/beetle-lynx-libretro)
-* [Report Issues Here](http://github.com/libretro/libretro-meta/issues)
+* [Report Issues Here](https://github.com/libretro/libretro-meta/issues)
 * [Official Website](http://mednafen.sourceforge.net/)

--- a/docs/library/mednafen_psx_hw.md
+++ b/docs/library/mednafen_psx_hw.md
@@ -209,5 +209,5 @@ Rumble only works when the corresponding user's device type is set to DualShock 
 ## External Links
 
 * [Libretro Repository](https://github.com/libretro/beetle-psx-libretro)
-* [Report Issues Here](http://github.com/libretro/libretro-meta/issues)
+* [Report Issues Here](https://github.com/libretro/libretro-meta/issues)
 * [Official Website](https://mednafen.github.io/)

--- a/docs/library/mednafen_psx_hw.md
+++ b/docs/library/mednafen_psx_hw.md
@@ -209,5 +209,5 @@ Rumble only works when the corresponding user's device type is set to DualShock 
 ## External Links
 
 * [Libretro Repository](https://github.com/libretro/beetle-psx-libretro)
-* [Report Issues Here](https://github.com/libretro/beetle-psx-libretro/issues)
+* [Report Issues Here](http://github.com/libretro/libretro-meta/issues)
 * [Official Website](https://mednafen.github.io/)

--- a/docs/library/meteor.md
+++ b/docs/library/meteor.md
@@ -72,5 +72,6 @@ To many to list
 
 ## External Links
 
-* [Official GitHub Repository](https://github.com/blastrock/meteor)  
 * [Libretro Repository](https://github.com/libretro/meteor-libretro)
+* [Report Issues Here](http://github.com/libretro/libretro-meta/issues)
+* [Official GitHub Repository](https://github.com/blastrock/meteor)  

--- a/docs/library/meteor.md
+++ b/docs/library/meteor.md
@@ -73,5 +73,5 @@ To many to list
 ## External Links
 
 * [Libretro Repository](https://github.com/libretro/meteor-libretro)
-* [Report Issues Here](http://github.com/libretro/libretro-meta/issues)
+* [Report Issues Here](https://github.com/libretro/libretro-meta/issues)
 * [Official GitHub Repository](https://github.com/blastrock/meteor)  

--- a/docs/library/mgba.md
+++ b/docs/library/mgba.md
@@ -91,6 +91,7 @@ Please file bugs on the [bug tracker](https://endrift.com/mgba/bugs/).
 
 ## External Links
 
+* [Libretro Repository](https://github.com/libretro/mgba)
+* [Report Issues Here](http://github.com/libretro/libretro-meta/issues)
 * [Official Website](http://mgba.io/)
 * [Official GitHub Repository](https://github.com/mgba-emu/mgba)
-* [Libretro Repository](https://github.com/libretro/mgba)

--- a/docs/library/mgba.md
+++ b/docs/library/mgba.md
@@ -92,6 +92,6 @@ Please file bugs on the [bug tracker](https://endrift.com/mgba/bugs/).
 ## External Links
 
 * [Libretro Repository](https://github.com/libretro/mgba)
-* [Report Issues Here](http://github.com/libretro/libretro-meta/issues)
+* [Report Issues Here](https://github.com/libretro/libretro-meta/issues)
 * [Official Website](http://mgba.io/)
 * [Official GitHub Repository](https://github.com/mgba-emu/mgba)

--- a/docs/library/prosystem.md
+++ b/docs/library/prosystem.md
@@ -76,6 +76,6 @@ This core does not have specific compatiblity issues
 
 ## External Links
 
-* [Official Website](http://gstanton.github.io/ProSystem1_3/)  
 * [Libretro Repository](https://github.com/libretro/prosystem-libretro)
 * [Report Issues Here](https://github.com/libretro/libretro-meta)
+* [Official Website](http://gstanton.github.io/ProSystem1_3/)  

--- a/docs/library/sameboy.md
+++ b/docs/library/sameboy.md
@@ -71,6 +71,6 @@ untested
 ## External Links
 
 * [Libretro Repository TBC](http://link)
-* [Report Issues Here](http://github.com/libretro/libretro-meta/issues)
+* [Report Issues Here](https://github.com/libretro/libretro-meta/issues)
 * [Official Website](https://sameboy.github.io/)
 * [Official Repository](https://github.com/LIJI32/SameBoy)  

--- a/docs/library/sameboy.md
+++ b/docs/library/sameboy.md
@@ -70,7 +70,7 @@ untested
 
 ## External Links
 
-* [Official Website](https://sameboy.github.io/)
-* [Official Repository](https://github.com/LIJI32/SameBoy)  
 * [Libretro Repository TBC](http://link)
 * [Report Issues Here](http://github.com/libretro/libretro-meta/issues)
+* [Official Website](https://sameboy.github.io/)
+* [Official Repository](https://github.com/LIJI32/SameBoy)  

--- a/docs/library/tgbdual.md
+++ b/docs/library/tgbdual.md
@@ -77,6 +77,6 @@ untested
 
 ## External Links
 
-* [Official Website](http://gigo.retrogames.com/download.html)  
 * [Libretro Repository](https://github.com/libretro/tgbdual-libretro)
 * [Report Issues Here](https://github.com/libretro/libretro-meta)
+* [Official Website](http://gigo.retrogames.com/download.html)  

--- a/docs/library/vba_next.md
+++ b/docs/library/vba_next.md
@@ -94,4 +94,4 @@ The VBA Next core supports one controller setting:
 ## External Links
 
 * [Libretro Repository](https://github.com/libretro/vba-next)
-* [Report Issues Here](http://github.com/libretro/libretro-meta/issues)
+* [Report Issues Here](https://github.com/libretro/libretro-meta/issues)

--- a/docs/library/vba_next.md
+++ b/docs/library/vba_next.md
@@ -94,3 +94,4 @@ The VBA Next core supports one controller setting:
 ## External Links
 
 * [Libretro Repository](https://github.com/libretro/vba-next)
+* [Report Issues Here](http://github.com/libretro/libretro-meta/issues)

--- a/docs/library/vbam.md
+++ b/docs/library/vbam.md
@@ -89,6 +89,6 @@ The VBA-M core supports one controller setting:
 ## External Links
 
 * [Libretro Repository](https://github.com/libretro/vbam-libretro)
-* [Report Issues Here](http://github.com/libretro/libretro-meta/issues)
+* [Report Issues Here](https://github.com/libretro/libretro-meta/issues)
 * [Official Website](http://vba-m.com/)
 * [Official Sourceforge Repository](http://sourceforge.net/projects/vbam/)

--- a/docs/library/vbam.md
+++ b/docs/library/vbam.md
@@ -88,6 +88,7 @@ The VBA-M core supports one controller setting:
 
 ## External Links
 
+* [Libretro Repository](https://github.com/libretro/vbam-libretro)
+* [Report Issues Here](http://github.com/libretro/libretro-meta/issues)
 * [Official Website](http://vba-m.com/)
 * [Official Sourceforge Repository](http://sourceforge.net/projects/vbam/)
-* [Libretro Repository](https://github.com/libretro/vbam-libretro)

--- a/docs/library/vecx.md
+++ b/docs/library/vecx.md
@@ -69,5 +69,6 @@ The core supports controller setting:
 
 ## External Links
 
-* [Official GitHub Repository of SDL Port](https://github.com/jhawthorn/vecx)
 * [Libretro Repository](https://github.com/libretro/libretro-vecx)
+* [Report Issues Here](http://github.com/libretro/libretro-meta/issues)
+* [Official GitHub Repository of SDL Port](https://github.com/jhawthorn/vecx)

--- a/docs/library/vecx.md
+++ b/docs/library/vecx.md
@@ -70,5 +70,5 @@ The core supports controller setting:
 ## External Links
 
 * [Libretro Repository](https://github.com/libretro/libretro-vecx)
-* [Report Issues Here](http://github.com/libretro/libretro-meta/issues)
+* [Report Issues Here](https://github.com/libretro/libretro-meta/issues)
 * [Official GitHub Repository of SDL Port](https://github.com/jhawthorn/vecx)

--- a/docs/library/virtualjaguar.md
+++ b/docs/library/virtualjaguar.md
@@ -76,5 +76,5 @@ The core supports one controller setting(s):
 ## External Links
 
 * [Libretro Repository](https://github.com/libretro/virtualjaguar-libretro)
-* [Report Issues Here](http://github.com/libretro/libretro-meta/issues)
+* [Report Issues Here](https://github.com/libretro/libretro-meta/issues)
 * [Official Website](https://icculus.org/virtualjaguar/)

--- a/docs/library/virtualjaguar.md
+++ b/docs/library/virtualjaguar.md
@@ -36,7 +36,7 @@ These are libretro features, not frontend or standalone emulator features.
 
 ## Options
 
-This core has a few options that can be tweaked from the core options menu. The default setting is bolded. 
+This core has a few options that can be tweaked from the core options menu. The default setting is bolded.
 
 - **Fast Blitter** (**Off**/On): Use a faster, but less accurate blitter.
 - **Doom Res Hack** (**Off**/On): Needed for Doom to run in its correct resolution..
@@ -76,5 +76,5 @@ The core supports one controller setting(s):
 ## External Links
 
 * [Libretro Repository](https://github.com/libretro/virtualjaguar-libretro)
-* [Report Issues Here](https://github.com/libretro/virtualjaguar-libretro/issues)
+* [Report Issues Here](http://github.com/libretro/libretro-meta/issues)
 * [Official Website](https://icculus.org/virtualjaguar/)


### PR DESCRIPTION
reordered all core.md external links to match template
pointed all issue reports to https://github.com/libretro/libretro-meta/issues/
