### PR TITLE
Add documentation for the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,28 @@
+# Libretro Documentation
+
+This is the source for the [libretro documentation](https://buildbot.libretro.com/docs/), powered by [MkDocs](http://www.mkdocs.org/).
+
+## Building
+
+1. Make sure you have [Python](https://www.python.org/) and [pip](https://pip.pypa.io) installed
+    ```
+    python --version
+    pip --version
+    ```
+
+2. Install MkDocs
+    ```
+    pip install mkdocs
+    ```
+
+3. Install MkDocs-Material
+    ```
+    pip install mkdocs-material
+    ```
+
+4. Build the site
+    ```
+    mkdocs build
+    ```
+
+5. The documentation will be built to the `site` directory


### PR DESCRIPTION
Not knowing how to build the documentation makes it difficult to contribute. This adds a README.md to help others build the docs site.