### PR TITLE
 Update Licenses doc and Add core list doc

### DIFF
--- a/docs/docguide/abc.md
+++ b/docs/docguide/abc.md
@@ -1,0 +1,116 @@
+// This is an alaphabetical list of all libretro cores available through RetroArch's Online Updater.
+
+3D Engine
+4DO
+2048
+Atari800
+Beetle bsnes
+Beetle Cygne
+Beetle GBA
+Beetle Handy
+Beetle NeoPop
+Beetle PC-FX
+Beetle PCE FAST
+Beetle PSX
+Beetle PSX HW
+Beetle Saturn
+Beetle SGX
+Beetle VB
+blueMSX
+bnes
+bsnes-mercury Accuracy
+bsnes-mercury Balanced
+bsnes-mercury Performance
+bsnes Accuracy
+bsnes Balanced
+bsnes C++98 (v085)
+bsnes Performance
+Caprice32
+ChaiLove
+CHIP-8 (Emux)
+Citra
+Commodore 64 (VICE)
+Commodore PLUS4 (VICE)
+Commodore VIC20 (VICE)
+Craft
+CrocoDS
+DeSmuME
+Dinothawr
+Dolphin
+DOSBox
+EightyOne
+FB Alpha
+FB Alpha 2012
+FB Alpha 2012 CPS-1
+FB Alpha 2012 CPS-2
+FB Alpha 2012 Neo Geo
+FCEUmm
+FFmpeg
+fMSX
+Fuse
+Gambatte
+Game Boy / Game Boy Color (Emux)
+Game Music Emu
+Gearboy
+Genesis Plus GX
+gpSP
+GW
+Handy
+Hatari
+higan Accuracy
+Imageviewer
+Lutro
+MAME
+MAME 2000
+MAME 2003
+MAME 2010
+MAME 2014
+MAME 2016
+melonDS
+MESS 2014
+Meteor
+mGBA
+Mr.Boom
+Mupen64Plus
+Mupen64Plus GLES3
+Neko Project II
+Neko Project II Kai
+NES / Famicom (Emux)
+Nestopia UE
+nSide Balanced
+NXEngine
+O2EM
+OpenLara
+P-UAE
+ParaLLEl N64
+PCSX ReARMed
+PicoDrive
+PocketCDG
+PokeMini
+PPSSPP
+PrBoom
+ProSystem
+PX68k
+QuickNES
+Redream
+Reicast
+RemoteJoy
+SameBoy
+ScummVM
+Sega Master System (Emux)
+Snes9x
+Snes9x 2002
+Snes9x 2005
+Snes9x 2005 Plus
+Snes9x 2010
+Stella
+TGB Dual
+TyrQuake
+UME 2014
+Uzem
+VBA-M
+VBA Next
+vecx
+Virtual Jaguar
+XRick
+Yabause

--- a/docs/tech/licenses.md
+++ b/docs/tech/licenses.md
@@ -1,94 +1,133 @@
 # Licenses
 
-There is software behind RetroArch and Lakka that is protected by Non-Commercial licenses. It is important to respect the wishes of the developers and people behind the respective projects. See below for a summary of the licenses behind RetroArch and its cores:
+There is software behind RetroArch and Lakka that is protected by Non-Commercial licenses. 
 
-Core | License | Non-Commercial
----- | ------- | --------------
-RetroArch|[GPLv3](https://github.com/libretro/RetroArch/blob/master/COPYING)|
-Lakka|Non-Commercial|Non-Commercial
-[2048](../library/2048.md)|[Public Domain](https://github.com/libretro/libretro-2048/blob/master/COPYING)|
-[Atari800](../library/atari800.md)|[GPLv2](https://github.com/atari800/atari800/blob/master/COPYING)|
-[beetle_gba](../library/beetle_gba.md)|GPLv2|
-[3D Engine](../library/3d_engine.md)|[GPLv3](https://github.com/libretro/libretro-3dengine/blob/master/license)|
-[4do](../library/4DO.md)|Non-commercial|Non-commercial
-[beetle_gba](../library/beetle_gba.md)|GPLv2|
-[beetle_lynx](../library/beetle_lynx.md)|GPLv2|
-[beetle_ngp](../library/beetle_ngp.md)|GPLv2|
-[beetle_pce_fast](../library/beetle_pce_fast.md)|GPLv2|
-[beetle_pcfx](../library/beetle_pcfx.md)|GPLv2|
-[beetle_psx_hw](../library/beetle_psx_hw.md)|GPLv2|
-[beetle_psx](../library/beetle_psx.md)|GPLv2|
-[Beetle Saturn](../library/beetle_saturn.md)|[GPLv2](https://github.com/libretro/beetle-saturn-libretro/blob/master/COPYING)|
-[beetle_sgx](../library/beetle_sgx.md)|GPLv2|
-[beetle_snes](../library/beetle_snes.md)|GPLv2|
-[beetle_vb](../library/beetle_vb.md)|GPLv2|
-[Beetle Cygne](../library/beetle_wswan.md)|[GPLv2](https://github.com/libretro/beetle-wswan-libretro/blob/master/COPYING)|
-[bluemsx](../library/bluemsx.md)|GPLv2|
-[bnes](../library/bnes.md)|GPLv3|
-[bsnes_accuracy](../library/bsnes_accuracy.md)|GPLv3|
-[bsnes_balanced](../library/bsnes_balanced.md)|GPLv3|
-[bsnes_cplusplus98](../library/bsnes_cplusplus98.md)|GPLv3|
-[bsnes_mercury_accuracy](../library/bsnes_mercury_accuracy.md)|GPLv3|
-[bsnes_mercury_balanced](../library/bsnes_mercury_balanced.md)|GPLv3|
-[bsnes_mercury_performance](../library/bsnes_mercury_performance.md)|GPLv3|
-[bsnes_performance](../library/bsnes_performance.md)|GPLv3|
-[Caprice32](../library/caprice32.md)|[GPLv2](https://github.com/ColinPitrat/caprice32/blob/master/COPYING.txt)|
-[chailove](../library/chailove.md)|MIT|
-[Citra](../library/citra.md)|[GPLv2](https://github.com/citra-emu/citra/blob/master/license.txt)|
-[craft](../library/craft.md)|MIT|
-[CrocoDS](../library/crocods.md)|[MIT](https://github.com/libretro/libretro-crocods/blob/master/LICENSE)|
-[DeSmuME](../library/desmume.md)|[GPLv2](https://github.com/TASVideos/desmume/blob/master/license.txt)|
-[dinothawr](../library/dinothawr.md)|[Non-commercial](https://github.com/libretro/Dinothawr/blob/master/LICENSE)|Non-Commercial
-[eightyone](../library/eightyone.md)|GPLv3|
-[Emux CHIP-8](../library/emux_chip8.md)|[GPLv2](https://github.com/libretro/emux/blob/master/COPYING)|
-[Emux GB](../library/emux_gb.md)|[GPLv2](https://github.com/libretro/emux/blob/master/COPYING)|
-[Emux NES](../library/emux_nes.md)|[GPLv2](https://github.com/libretro/emux/blob/master/COPYING)|
-[Emux SMS](../library/emux_sms.md)|[GPLv2](https://github.com/libretro/emux/blob/master/COPYING)|
-fba|Non-commercial|Non-commercial
-[FCEUmm](../library/fceumm.md)|[GPLv2](https://github.com/libretro/libretro-fceumm/blob/master/Copying)|
-[ffmpeg](../library/ffmpeg.md)|LGPLv2, GPLv2|
-fmsx|Non-commercial|Non-commercial
-[gambatte](../library/gambatte.md)|GPLv2|
-[game_music_emu](../library/game_music_emu.md)|LGPLv2, GPLv2|
-[genesis_plus_gx](../library/genesis_plus_gx.md)|[Non-commercial](https://github.com/libretro/Genesis-Plus-GX/blob/master/LICENSE.txt)|Non-commercial
-[gpsp](../library/gpsp.md)|GPLv2|
-[gw](../library/gw.md)|zlib|
-[handy](../library/handy.md)|zlib|
-[hatari](../library/hatari.md)|GPLv2|
-[higan_accuracy](../library/higan_accuracy.md)|GPLv3|
-[imageviewer](../library/imageviewer.md)|GPLv3|
-[lutro](../library/lutro.md)|MIT|
-[mame2003](../library/mame2003.md)|BSD-3-Clause & GNU GPLv2|
-[melonDS](../library/melonds.md)|[GPLv3](https://github.com/libretro/melonDS/blob/master/LICENSE)|
-[meteor](../library/meteor.md)|GPLv3|
-[mgba](../library/mgba.md)|MPLv2.0|
-[mr_boom](../library/mr_boom.md)|MIT|
-[nestopia_ue](../library/nestopia_ue.md)|GPLv2|
-[nxengine](../library/nxengine.md)|GPLv3|
-[OpenLara](../library/openlara.md)|[2-clause BSD](https://github.com/XProger/OpenLara/blob/master/README.md)|
-[PCSX ReARMed](../library/pcsx_rearmed.md)|[GPLv2](https://github.com/libretro/pcsx_rearmed/blob/master/COPYING)|
-[Picodrive](../library/picodrive.md)|[Non-commercial](https://github.com/libretro/picodrive/blob/master/COPYING)|Non-commercial
-[pocketcdg](../library/pocketcdg.md)|MIT|
-[pokemini](../library/pokemini.md)|GPLv3|
-[ppsspp](../library/ppsspp.md)|GPLv2|
-[prboom](../library/prboom.md)|GPLv2|
-[prosystem](../library/prosystem.md)|GPLv2|
-P-UAE|[GPLv2](https://github.com/libretro/PUAE/blob/master/COPYING)|
-[quicknes](../library/quicknes.md)|LGPLv2.1+|
-[redream](../library/redream.md)|GPLv3|
-[Reicast](../library/reicast.md)|[GPLv2](https://github.com/reicast/reicast-emulator/blob/master/LICENSE)|
-[SameBoy](../library/sameboy.md)|[MIT](https://github.com/libretro/SameBoy/blob/master/LICENSE)|
-[snes9x_2002](../library/snes9x_2002.md)|Non-commercial|Non-commercial
-[snes9x_2005](../library/snes9x_2005.md)|Non-commercial|Non-commercial
-[snes9x_2005_plus](../library/snes9x_2005_plus.md)|Non-commercial|Non-commercial
-[snes9x_2010](../library/snes9x_2010.md)|Non-commercial|Non-commercial
-[snes9x](../library/snes9x.md)|Non-commercial|Non-commercial
-[stella](../library/Stella.md)|GPLv2|
-[tgbdual](../library/tgbdual.md)|GPLv2|
-[TyrQuake](../library/tyrquake.md)|[GPLv2](https://github.com/libretro/tyrquake/blob/master/gnu.txt)|
-[vbam](../library/vbam.md)|GPLv2|
-[vba_next](../library/vba_next.md)|GPLv2|
-[vecx](../library/vecx.md)|GPLv3|
-[virtualjaguar](../library/virtualjaguar.md)|GPLv3|
-[xrick](../library/xrick.md)|GPLv3|
-[Yabause](../library/Yabause.md)|GPLv2|
+It is important to respect the wishes of the developers and people behind the respective projects. 
+
+See below for a summary of the licenses behind RetroArch and its cores:
+
+## Libretro
+
+| Libretro  | License                                                            | Non-commercial |
+|-----------| -------------------------------------------------------------------| ---------------|
+| RetroArch | [GPLv3](https://github.com/libretro/RetroArch/blob/master/COPYING) |                |
+| Lakka     | Non-Commercial                                                     | Non-Commercial |
+
+## Cores
+
+| Core                                             			           | License                                                                                   | Non-commercial |
+|----------------------------------------------------------------------|-------------------------------------------------------------------------------------------|----------------|
+| [2048](../library/2048.md)                       			           | [Public Domain](https://github.com/libretro/libretro-2048/blob/master/COPYING)            |                |
+| [3D Engine](../library/3d_engine.md)             			           | [GPLv3](https://github.com/libretro/libretro-3dengine/blob/master/license)                |                |
+| [4DO](../library/4DO.md)                         			           | Non-commercial                                                                            | Non-commercial |
+| [Atari800](../library/atari800.md)               			           | [GPLv2](https://github.com/atari800/atari800/blob/master/COPYING)                         |                |
+| [Beetle Cygne](../library/beetle_wswan.md)       			           | [GPLv2](https://github.com/libretro/beetle-wswan-libretro/blob/master/COPYING)            |                |
+| [Beetle GBA](../library/beetle_gba.md)           			           | [GPLv2](https://github.com/libretro/beetle-gba-libretro/blob/master/COPYING)              |                |
+| [Beetle Handy](../library/beetle_lynx.md)        			           | [GPLv2](https://github.com/libretro/beetle-lynx-libretro/blob/master/COPYING)             |                |
+| [Beetle NeoPop](../library/beetle_ngp.md)        			           | [GPLv2](https://github.com/libretro/beetle-ngp-libretro)                                  |                |
+| [Beetle PC-FX](../library/beetle_pcfx.md)        			           | [GPLv2](https://github.com/libretro/beetle-pcfx-libretro/blob/master/COPYING)             |                |
+| [Beetle PCE FAST](../library/beetle_pce_fast.md) 			           | [GPLv2](https://github.com/libretro/beetle-pce-fast-libretro/blob/master/COPYING)         |                |
+| [Beetle PSX](../library/beetle_psx.md)           			           | [GPLv2](https://github.com/libretro/beetle-psx-libretro)                                  |                |
+| [Beetle PSX HW](../library/beetle_psx_hw.md)     			           | [GPLv2](https://github.com/libretro/beetle-psx-libretro)                                  |                |
+| [Beetle SGX](../library/beetle_sgx.md)           			           | [GPLv2](https://github.com/libretro/beetle-supergrafx-libretro/blob/master/COPYING)       |                |
+| [Beetle Saturn](../library/beetle_saturn.md)     			           | [GPLv2](https://github.com/libretro/beetle-saturn-libretro/blob/master/COPYING)           |                |
+| [Beetle VB](../library/beetle_vb.md)             			           | [GPLv2](https://github.com/libretro/beetle-vb-libretro/blob/master/COPYING)               |                |
+| [Beetle bsnes](../library/beetle_snes.md)       			           | [GPLv2](https://github.com/libretro/beetle-bsnes-libretro/blob/master/COPYING)            |                |
+| [CHIP-8 (Emux)](../library/emux_chip8.md)        			           | [GPLv2](https://github.com/libretro/emux/blob/master/COPYING)                             |                |
+| [Caprice32](../library/caprice32.md)             			           | [GPLv2](https://github.com/ColinPitrat/caprice32/blob/master/COPYING.txt)                 |                |
+| [ChaiLove](../library/chailove.md)               			           | [MIT](https://github.com/RobLoach/ChaiLove/blob/master/LICENSE.md)                        |                |
+| [Citra](../library/citra.md)                     			           | [GPLv2](https://github.com/citra-emu/citra/blob/master/license.txt)                       |                |
+| Commodore 64 (VICE)                             			           | [GPLv2](https://github.com/r-type/vice3.0-libretro/blob/master/vice/COPYING)              |                |
+| Commodore PLUS4 (VICE)                           			           | [GPLv2](https://github.com/r-type/vice3.0-libretro/blob/master/vice/COPYING)              |                |
+| Commodore VIC20 (VICE)                           			           | [GPLv2](https://github.com/r-type/vice3.0-libretro/blob/master/vice/COPYING)              |                |
+| [Craft](../library/craft.md)                     			           | [MIT](https://github.com/libretro/Craft/blob/master/LICENSE.md)                           |                |
+| [CrocoDS](../library/crocods.md)                 			           | [MIT](https://github.com/libretro/libretro-crocods/blob/master/LICENSE)                   |                |
+| DOSBox                                           			           | [GPLv2](https://github.com/libretro/dosbox-libretro/blob/master/COPYING)                  |                |
+| [DeSmuME](../library/desmume.md)                 			           | [GPLv2](https://github.com/TASVideos/desmume/blob/master/license.txt)                     |                |
+| [Dinothawr](../library/dinothawr.md)             			           | [Non-commercial](https://github.com/libretro/Dinothawr/blob/master/LICENSE)               | Non-commercial |
+| Dolphin                                          			           | [GPLv2](https://github.com/dolphin-emu/dolphin/blob/master/license.txt)                   |                |
+| [EightyOne](../library/eightyone.md)             			           | [GPLv3](https://github.com/libretro/81-libretro/blob/master/LICENSE)                      |                |
+| FB Alpha                                         			           | [Non-commercial](https://www.fbalpha.com/license/)                                        | Non-commercial |
+| FB Alpha 2012                                    			           | [Non-commercial](https://www.fbalpha.com/license/)                                        | Non-commercial |
+| FB Alpha 2012 CPS-1                              			           | [Non-commercial](https://www.fbalpha.com/license/)                                        | Non-commercial |
+| FB Alpha 2012 CPS-2                              			           | [Non-commercial](https://www.fbalpha.com/license/)                                        | Non-commercial |
+| FB Alpha 2012 Neo Geo                            		               | [Non-commercial](https://www.fbalpha.com/license/)                                        | Non-commercial |
+| [FCEUmm](../library/fceumm.md)                                       | [GPLv2](https://github.com/libretro/libretro-fceumm/blob/master/Copying)                  |                |
+| [FFmpeg](../library/ffmpeg.md)                                       | [LGPLv2, GPLv2](https://github.com/libretro/FFmpeg/blob/master/LICENSE.md)                |                |
+| Fuse                                                                 | [GPLv3](https://github.com/libretro/fuse-libretro/blob/master/LICENSE)                    |                |
+| [GW](../library/gw.md)                                               | [zlib](https://github.com/libretro/gw-libretro/blob/master/LICENSE)                       |                |
+| [Gambatte](../library/gambatte.md)                                   | [GPLv2](https://github.com/libretro/gambatte-libretro/blob/master/COPYING)                |                |
+| [Game Boy / Game Boy Color (Emux)](../library/emux_gb.md)            | [GPLv2](https://github.com/libretro/emux/blob/master/COPYING)                             |                |
+| [Game Music Emu](../library/game_music_emu.md)            		   | [GPLv3](https://github.com/libretro/libretro-gme/blob/master/LICENSE)                     |                |
+| Gearboy                                                   	       | [GPLv3](https://github.com/libretro/Gearboy/blob/master/LICENSE)                          |                |
+| [Genesis Plus GX](../library/genesis_plus_gx.md)          		   | [Non-commercial](https://github.com/libretro/Genesis-Plus-GX/blob/master/LICENSE.txt)     | Non-commercial |
+| [Handy](../library/handy.md)							    		   | [zlib](https://sourceforge.net/projects/handy/)                                           |                |
+| [Hatari](../library/hatari.md)									   | [GPLv2](https://github.com/libretro/hatari/blob/master/readme.txt)                        |                |
+| [Imageviewer](../library/imageviewer.md)				    		   | [GPLv3](https://github.com/libretro/RetroArch/blob/master/COPYING)                        |                |
+| [Lutro](../library/lutro.md)							    	       | [MIT](https://github.com/libretro/libretro-lutro/blob/master/LICENSE)                     |                |
+| MAME																   | [BSD-3-Clause & GNU GPLv2](http://mamedev.org/legal.html)                                 |                |
+| MAME 2000												    	       | [BSD-3-Clause & GNU GPLv2](http://mamedev.org/legal.html)                                 |                |
+| [MAME 2003](../library/mame2003.md)								   | [BSD-3-Clause & GNU GPLv2](http://mamedev.org/legal.html)                                 |                |
+| MAME 2010                                                 		   | [BSD-3-Clause & GNU GPLv2](http://mamedev.org/legal.html)                                 |                |
+| MAME 2014                                                 		   | [BSD-3-Clause & GNU GPLv2](http://mamedev.org/legal.html)                                 |                |
+| MAME 2016                                                 		   | [BSD-3-Clause & GNU GPLv2](http://mamedev.org/legal.html)                                 |                |
+| MESS 2014                                                 		   | [BSD-3-Clause & GNU GPLv2](http://mamedev.org/legal.html)                                 |                |
+| [Meteor](../library/meteor.md)                            		   | [GPLv3](https://github.com/libretro/meteor-libretro/blob/master/COPYING)                  |                |
+| [Mr.Boom](../library/mr_boom.md)                          		   | [MIT](https://github.com/libretro/mrboom-libretro/blob/master/LICENSE)                    |                |
+| Mupen64Plus                                               		   | [GPLv3](https://github.com/libretro/mupen64plus-libretro/blob/master/LICENSE)             |                |
+| Mupen64Plus GLES3                                         		   | [GPLv3](https://github.com/libretro/mupen64plus-libretro/blob/master/LICENSE)             |                |
+| [NES / Famicom (Emux)](../library/emux_nes.md)            		   | [GPLv2](https://github.com/libretro/emux/blob/master/COPYING)                             |                |
+| [NXEngine](../library/nxengine.md)                        		   | [GPLv3](https://github.com/gameblabla/nxengine-nspire/blob/master/LICENSE)                |                |
+| Neko Project II                                           		   | Awaiting description.                                                                     |                |
+| Neko Project II Kai                                                  | [MIT](https://github.com/AZO234/NP2kai/blob/master/LICENSE)                               |                |
+| [Nestopia UE](../library/nestopia_ue.md)                             | [GPLv2](https://github.com/libretro/nestopia/blob/master/COPYING)                         |                |
+| O2EM                                                                 | [Artistic License](https://sourceforge.net/projects/o2em/)                                |                |
+| [OpenLara](../library/openlara.md)                                   | [BSD-2-Clause](https://github.com/libretro/OpenLara/blob/master/README.md)                |                |
+| P-UAE                                                                | [GPLv2]((https://github.com/libretro/PUAE/blob/master/COPYING))                           |                |
+| [PCSX ReARMed](../library/pcsx_rearmed.md)                           | [GPLv2](https://github.com/libretro/pcsx_rearmed/blob/master/COPYING)                     |                |
+| [PPSSPP](../library/ppsspp.md)                                       | [GPLv2](https://github.com/libretro/ppsspp/blob/master/LICENSE.TXT)                       |                |
+| PX68k                                                                | Awaiting description.                                                                     |                |
+| ParaLLEl N64                                                         | [GPLv3](https://github.com/libretro/mupen64plus-libretro/blob/master/LICENSE)             |                |
+| [PicoDrive](../library/picodrive.md)                                 | [Non-commercial](https://github.com/libretro/picodrive/blob/master/COPYING)               | Non-commercial |
+| [PocketCDG](../library/pocketcdg.md)                                 | [MIT](https://github.com/libretro/libretro-pocketcdg/blob/master/LICENSE)                 |                |
+| [PokeMini](../library/pokemini.md)                                   | [GPLv3](https://github.com/libretro/PokeMini/blob/master/LICENSE)                         |                |
+| [PrBoom](../library/prboom.md)                                       | [GPLv2](https://github.com/libretro/libretro-prboom/blob/master/COPYING)                  |                |
+| [ProSystem](..//library/prosystem.md)                                | [GPLv2](https://github.com/libretro/prosystem-libretro/blob/master/License.txt)           |                |
+| [QuickNES](../library/quicknes.md)                                   | [LGPLv2.1+](https://github.com/kode54/QuickNES/blob/master/COPYING)                       |                |
+| [Redream](../library/redream.md)                                     | [GPLv3](https://github.com/libretro/redream/blob/master/LICENSE.txt)                      |                |
+| [Reicast](../library/reicast.md)                                     | [GPLv2](https://github.com/libretro-mirrors/reicast-emulator/blob/master/LICENSE)         |                |
+| RemoteJoy                                                            | Awaiting description.                                                                     |                |
+| [SameBoy](../library/sameboy.md)                                     | [MIT](https://github.com/libretro/SameBoy/blob/master/LICENSE)                            |                |
+| [ScummVM](../library/scummvm.md)                                     | [GPLv2](https://github.com/libretro/scummvm/blob/master/COPYING)                          |                |
+| [Sega Master System (Emux)](../library/emux_sms.md                   | [GPLv2](https://github.com/libretro/emux/blob/master/COPYING)                             |                |
+| [Snes9x](../library/snes9x.md)                                       | [Non-commercial](https://github.com/libretro/snes9x/blob/master/docs/snes9x-license.txt)  | Non-commercial |
+| [Snes9x 2002](../library/snes9x_2002.md)                             | [Non-commercial](https://github.com/libretro/snes9x/blob/master/docs/snes9x-license.txt)  | Non-commercial | 
+| [Snes9x 2005](../library/snes9x_2005.md)                             | [Non-commercial](https://github.com/libretro/snes9x/blob/master/docs/snes9x-license.txt)  | Non-commercial |
+| [Snes9x 2005 Plus](../library/snes9x_2005_plus.md)                   | [Non-commercial](https://github.com/libretro/snes9x/blob/master/docs/snes9x-license.txt)  | Non-commercial |
+| [Snes9x 2010](../library/snes9x_2010.md)                             | [Non-commcercial](https://github.com/libretro/snes9x/blob/master/docs/snes9x-license.txt) | Non-commercial |
+| [Stella](../library/Stella.md)                                       | [GPLv2](https://github.com/stella-emu/stella/blob/master/License.txt)                     |                |
+| [TGB Dual](../library/tgbdual.md)                                    | [GPLv2](https://github.com/libretro/tgbdual-libretro/blob/master/docs/COPYING-2.0.txt)    |                |
+| [TyrQuake](../library/tyrquake.md)                                   | [GPLv2](https://github.com/libretro/tyrquake/blob/master/gnu.txt)                         |                |
+| UME 2014                                                             | [BSD-3-Clause & GNU GPLv2](http://mamedev.org/legal.html)                                 |                |
+| Uzem                                                                 | [GPLv3](https://github.com/Uzebox/uzebox/blob/master/gpl-3.0.txt)                         |                |
+| [VBA Next](../library/vba_next.md)                                   | GPLv2                                                                                     |                |
+| [VBA-M](../library/vbam.md)                                          | [GPLv2](https://github.com/libretro/vbam-libretro/blob/master/doc/gpl.txt)                |                |
+| [Virtual Jaguar](../library/virtualjaguar.md)                        | [GPLv3](https://github.com/libretro/virtualjaguar-libretro/blob/master/docs/GPLv3)        |                |
+| [XRick](../library/xrick.md)                                         | [GPLv3](https://github.com/libretro/xrick-libretro/blob/master/README)                    |                |
+| [Yabause](../library/Yabause.md)									   | [GPLv2](https://github.com/libretro/yabause/blob/master/yabause/COPYING)                  |                |
+| [blueMSX](../library/bluemsx.md)									   | [GPLv2[(https://github.com/libretro/blueMSX-libretro)                                     |                |
+| [bnes](../library/bnes.md)                                           | [GPLv3](https://github.com/libretro/bnes-libretro)                                        |                |
+| [bsnes Accuracy](../library/bsnes_accuracy.md)                       | [GPLv3](https://github.com/libretro/bsnes-libretro)                                       |                |
+| [bsnes Balanced](../library/bsnes_balanced.md)                       | [GPLv3](https://github.com/libretro/bsnes-libretro)                                       |                |
+| [bsnes C++98 (v085)](../library/bsnes_cplusplus98.md)                | [GPLv3](https://byuu.org/emulation/higan/licensing)                                       |                |
+| [bsnes Performance](../library/bsnes_performance.md)                 | [GPLv3](https://github.com/libretro/bsnes-libretro)                                       |                |
+| [bsnes-mercury Accuracy](../library/bsnes_mercury_accuracy.md)       | [GPLv3](https://github.com/libretro/bsnes-mercury/blob/master/LICENSE)                    |                |
+| [bsnes-mercury Balanced](../library/bsnes_mercury_balanced.md)       | [GPLv3](https://github.com/libretro/bsnes-mercury/blob/master/LICENSE)                    |                |
+| [bsnes-mercury Performance](../library/bsnes_mercury_performance.md) | [GPLv3](https://github.com/libretro/bsnes-mercury/blob/master/LICENSE)                    |                |
+| fMSX                                                                 | [Non-commercial](https://github.com/libretro/fmsx-libretro/blob/master/LICENSE)           | Non-commercial |
+| [gpSP](../library/gpsp.md)                                           | [GPLv2](https://github.com/libretro/gpsp/blob/master/COPYING)                             |                |
+| [higan Accuracy](../library/higan_accuracy.md)                       | [GPLv3](https://gitlab.com/higan/higan/blob/master/LICENSE.txt)                           |                |
+| [mGBA](../library/mgba.md)                                           | [MPLv2.0](https://github.com/libretro/mgba/blob/master/LICENSE)                           |                |
+| [melonDS](../library/melonds.md)                                     | [GPLv3](https://github.com/libretro/melonDS/blob/master/LICENSE)                          |                |
+| nSide Balanced                                                       | [GPLv3](https://github.com/hex-usr/nSide/blob/master/gpl-3.0.txt)                         |                |
+| [vecx](../library/vecx.md)                                           | [GPLv3](https://github.com/libretro/libretro-vecx/blob/master/LICENSE.md)                 |                |

--- a/docs/tech/licenses.md
+++ b/docs/tech/licenses.md
@@ -99,7 +99,7 @@ See below for a summary of the licenses behind RetroArch and its cores:
 | RemoteJoy                                                            | Awaiting description.                                                                     |                |
 | [SameBoy](../library/sameboy.md)                                     | [MIT](https://github.com/libretro/SameBoy/blob/master/LICENSE)                            |                |
 | [ScummVM](../library/scummvm.md)                                     | [GPLv2](https://github.com/libretro/scummvm/blob/master/COPYING)                          |                |
-| [Sega Master System (Emux)](../library/emux_sms.md                   | [GPLv2](https://github.com/libretro/emux/blob/master/COPYING)                             |                |
+| [Sega Master System (Emux)](../library/emux_sms.md)                  | [GPLv2](https://github.com/libretro/emux/blob/master/COPYING)                             |                |
 | [Snes9x](../library/snes9x.md)                                       | [Non-commercial](https://github.com/libretro/snes9x/blob/master/docs/snes9x-license.txt)  | Non-commercial |
 | [Snes9x 2002](../library/snes9x_2002.md)                             | [Non-commercial](https://github.com/libretro/snes9x/blob/master/docs/snes9x-license.txt)  | Non-commercial | 
 | [Snes9x 2005](../library/snes9x_2005.md)                             | [Non-commercial](https://github.com/libretro/snes9x/blob/master/docs/snes9x-license.txt)  | Non-commercial |
@@ -115,7 +115,7 @@ See below for a summary of the licenses behind RetroArch and its cores:
 | [Virtual Jaguar](../library/virtualjaguar.md)                        | [GPLv3](https://github.com/libretro/virtualjaguar-libretro/blob/master/docs/GPLv3)        |                |
 | [XRick](../library/xrick.md)                                         | [GPLv3](https://github.com/libretro/xrick-libretro/blob/master/README)                    |                |
 | [Yabause](../library/Yabause.md)									   | [GPLv2](https://github.com/libretro/yabause/blob/master/yabause/COPYING)                  |                |
-| [blueMSX](../library/bluemsx.md)									   | [GPLv2[(https://github.com/libretro/blueMSX-libretro)                                     |                |
+| [blueMSX](../library/bluemsx.md)									   | [GPLv2](https://github.com/libretro/blueMSX-libretro)                                     |                |
 | [bnes](../library/bnes.md)                                           | [GPLv3](https://github.com/libretro/bnes-libretro)                                        |                |
 | [bsnes Accuracy](../library/bsnes_accuracy.md)                       | [GPLv3](https://github.com/libretro/bsnes-libretro)                                       |                |
 | [bsnes Balanced](../library/bsnes_balanced.md)                       | [GPLv3](https://github.com/libretro/bsnes-libretro)                                       |                |

--- a/docs/tech/licenses.md
+++ b/docs/tech/licenses.md
@@ -96,7 +96,7 @@ See below for a summary of the licenses behind RetroArch and its cores:
 | [QuickNES](../library/quicknes.md)                                   | [LGPLv2.1+](https://github.com/kode54/QuickNES/blob/master/COPYING)                       |                |
 | [Redream](../library/redream.md)                                     | [GPLv3](https://github.com/libretro/redream/blob/master/LICENSE.txt)                      |                |
 | [Reicast](../library/reicast.md)                                     | [GPLv2](https://github.com/libretro-mirrors/reicast-emulator/blob/master/LICENSE)         |                |
-| RemoteJoy                                                            | Awaiting description.                                                                     |                |
+| RemoteJoy                                                            | GPLv2                                                                     |                |
 | [SameBoy](../library/sameboy.md)                                     | [MIT](https://github.com/libretro/SameBoy/blob/master/LICENSE)                            |                |
 | [ScummVM](../library/scummvm.md)                                     | [GPLv2](https://github.com/libretro/scummvm/blob/master/COPYING)                          |                |
 | [Sega Master System (Emux)](../library/emux_sms.md)                  | [GPLv2](https://github.com/libretro/emux/blob/master/COPYING)                             |                |


### PR DESCRIPTION
@RobLoach Licenses doc is very near completion. Now it's only missing info for Neko Project II and PX68k.