### PR TITLE
create RetroArch Keyboard Controls doc

### DIFF
--- a/docs/guides/retroarch-keyboard-controls.md
+++ b/docs/guides/retroarch-keyboard-controls.md
@@ -1,0 +1,45 @@
+# RetroArch Keyboard Controls
+
+## RetroArch Keyboard to RetroPad Mapping
+
+| User 1 Keyboard |                                              | 
+|-----------------|----------------------------------------------|
+| `Z`                             | ![](../library/images/RetroPad/Retro_B_Round.png)       |
+| `A`                             | ![](../library/images/RetroPad/Retro_Y_Round.png)       | 
+| `X`                             | ![](../library/images/RetroPad/Retro_A_Round.png)       |
+| `S`                             | ![](../library/images/RetroPad/Retro_X_Round.png)       |
+| `Q`                             | ![](../library/images/RetroPad/Retro_L1.png)            |
+| `W`                             | ![](../library/images/RetroPad/Retro_R1.png)            |
+|                                 | ![](../library/images/RetroPad/Retro_Select.png)        |
+| `Enter`                         | ![](../library/images/RetroPad/Retro_Start.png)         |
+| `Up`                            | ![](../library/images/RetroPad/Retro_Dpad_Up.png)       |
+| `Down`                          | ![](../library/images/RetroPad/Retro_Dpad_Down.png)     |
+| `Left`                          | ![](../library/images/RetroPad/Retro_Dpad_Left.png)     |
+| `Right`                         | ![](../library/images/RetroPad/Retro_Dpad_Right.png)    |
+
+
+## RetroArch GUI Keyboard Controls
+
+In addition to the RetroPad mapping, RetroArch provides a number of other default keyboard mappings.
+
+* `Enter` = Confirm
+* `Backspace` = Cancel
+* `/` = Search prompt
+* `Delete` = Delete input bind
+* `Spacebar` = Reset option to default
+* `Right Shift` = Show tooltip
+* `Page Up` and `Page Down` = Fast scrolling through files by jumping to the next letter.
+
+## RetroArch Core Keyboard Controls
+
+In addition to the RetroPad mapping, various in-core hotkeys are mapped by default, including:
+
+* `Escape` = Quit
+* `F1` = Quick Menu toggle
+* `F2` = Save State
+* `F4` = Load State
+* `F` = Fullscreen toggle
+* `Spacebar` = Fast-Forward toggle
+* `F8` = Screenshot
+
+Hotkey binds can be configured at `Settings` → `Input` → 'Input Hotkey Binds'. If you map `Enable Hotkeys` to a key, it will require that key to be held in order to trigger any hotkeys. This can be useful in avoiding keyboard mapping conflicts between RetroArch and cores cores that use the keyboard for input. Hotkeys can also be mapped to RetroPad buttons.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -216,6 +216,7 @@ pages:
     - Installing and Updating RetroArch:
       - 'Windows': 'guides/install-windows.md'
     - Getting Started:
+      - 'Keyboard Controls': 'guides/retroarch-keyboard-controls.md'
       - 'Windows': 'guides/windows.md'
       - 'Command-line interface (CLI)': 'guides/cli-intro.md'
       - 'Generating Logs': 'guides/generating-retroarch-logs.md'


### PR DESCRIPTION
The need for this doc comes up in the forums.

There is a good, albeit incomplete, keyboard chart in the Windows Getting Started  guide that could be moved here and linked -- the RA keyboard controls are cross-platform. That may be the next PR.