### PR TITLE
Nestopia does NOT support cheevos (yet?)

### DIFF
--- a/docs/guides/retroachievements.md
+++ b/docs/guides/retroachievements.md
@@ -62,7 +62,7 @@ You can also check the progress of your friends and add comments on their trophi
 | [Mesen](https://github.com/SourMesen/Mesen)           | ✔         | |
 | [FCEUmm](https://github.com/libretro/libretro-fceumm) | ✔         | |
 | [QuickNES](https://github.com/libretro/QuickNES_Core) | ✔         | On Android has a [known issue](https://github.com/libretro/RetroArch/issues/3973) |
-| [Nestopia UE](https://github.com/libretro/nestopia)   | ✔         | |
+| [Nestopia UE](https://github.com/libretro/nestopia)   | ✕         | |
 | [bnes](https://github.com/libretro/bnes-libretro)     | ✕         | |
 | [Emux NES](https://github.com/libretro/emux)          | ✕         | |
 


### PR DESCRIPTION
I'm aware about this commit on Nestopia repo: https://github.com/libretro/nestopia/commit/5ecea4402cb6722405afb5fd23db8de411122eb5
But looks like it's not enough to make Nestopia work with RetroAchievements.

I've tested a few minutes ago on Android/RetroArch 1.7.1(stable)/Nestopia 5ecea44 and it didn't work. Tested also on Linux/RetroArch 1.7.1 (b3d3cbd)/Nestopia (5ecea44), same thing.

Simplest way I know to test it: Get the Morph Ball on Metroid. Simply start the game and go left to get the Morph Ball.

![nestopiafail](https://cdn.discordapp.com/attachments/343890679686103040/418711589135581184/Screenshot_2018-03-01-07-09-55-366_com.retroarch.png)