### PR TITLE
Fix Markdown code blocks nested within bullets.

### DIFF
--- a/docs/tech/new-translations.md
+++ b/docs/tech/new-translations.md
@@ -10,6 +10,7 @@
 * `intl/msg_hash_xx.h` (new file)
 * `intl/msg_hash_us.h`
 * `menu/menu_setting.c`
+* `griffin/griffin.c`
 
 ## Instructions
 
@@ -38,25 +39,51 @@
 11. Open `Makefile.common`
 12. Add `intl/msg_hash_xx.o` to `OBJS`
 13. Copy `intl/msg_hash_us.c` to `intl/msg_hash_xx.c`
-14. Open `intl/msg_hash_xx.c`
-15. Rename the `menu_hash_get_help_us_enum()` function to `menu_hash_get_help_xx_enum()`
-16. Rename the `menu_hash_to_str_us_label_enum()` function to `menu_hash_to_str_xx_label_enum()`
-17. Rename the `menu_hash_to_str_us()` function to `msg_hash_to_str_xx()` and, inside that same function:
+14. Decide if `intl/msg_hash_xx.c` should use UTF-8 + BOM encoding. See the section below
+15. Open `intl/msg_hash_xx.c`
+16. Rename the `menu_hash_get_help_us_enum()` function to `menu_hash_get_help_xx_enum()`
+17. Rename the `menu_hash_to_str_us_label_enum()` function to `menu_hash_to_str_xx_label_enum()`
+18. Rename the `menu_hash_to_str_us()` function to `msg_hash_to_str_xx()` and, inside that same function:
     * Replace the call to `menu_hash_to_str_us_label_enum()` with a call to `menu_hash_to_str_xx_label_enum()`
     * Replace the `#include "msg_hash_us.h"` line with #include "msg_hash_xx.h"
-18. Open `intl/msg_hash_us.h`
-19. Add a
+19. Open `intl/msg_hash_us.h`
+20. Add a
      ```c
      MSG_HASH(MENU_ENUM_LABEL_VALUE_LANG_XXXXX, "Xxxxx")
      ```
     block
-20. Copy `intl/msg_hash_us.h` to `intl/msg_hash_xx.h`
-21. Open `menu/menu_setting.c`
-22. Add a
+21. Copy `intl/msg_hash_us.h` to `intl/msg_hash_xx.h`
+22. Decide if `intl/msg_hash_xx.h` should use UTF-8 + BOM encoding. See the section below
+23. Open `menu/menu_setting.c`
+24. Add a
      ```c
      modes[RETRO_LANGUAGE_XXXXX] = msg_hash_to_str(MENU_ENUM_LABEL_VALUE_LANG_XXXXX);
      ```
     assignment to the `setting_get_string_representation_uint_user_language()` function
+25. Open `griffin/griffin.c`
+26. Add a `#include "../intl/msg_hash_xx.c"` line below the existing, similar
+    ones for other languages.
+
+### Encoding of translation files
+
+* Translation files (`intl/msg_hash_xx.{c,h}`) in general must be UTF-8 encoded
+* For some languages, these files need to have a "UTF-8 Unicode (with BOM)"
+  encoding, this is, UTF-8 and a
+  [BOM](https://en.wikipedia.org/wiki/Byte_order_mark). AFAIK this is so
+  because a requirement of the MSVC compilers (Windows platform). Examples of
+  this as of now are:
+
+    * `msg_hash_ar.{c,h}`
+    * `msg_hash_chs.{c,h}`
+    * `msg_hash_cht.{c,h}`
+    * `msg_hash_ja.{c,h}`
+    * `msg_hash_ko.{c,h}`
+    * `msg_hash_pl.{c,h}`
+    * `msg_hash_ru.{c,h}`
+    * `msg_hash_vn.h`
+
+* Be careful when creating and editing your new translation files as some text
+  editors do strip the BOM without warning.
 
 ### Translation
 
@@ -71,6 +98,7 @@ by replacing the English original ones with its translations.
 
 * Commit [45580cb](https://github.com/libretro/RetroArch/commit/45580cb9a8f0fcd0a87f00eadf26d87f05289485)
 * Commit [d8f1a08](https://github.com/libretro/RetroArch/commit/d8f1a08a4758851d5530d311303146257cbf8216)
+* Commit [7a0428f](https://github.com/libretro/RetroArch/commit/7a0428fc769fd0eca663207134bec311aa3e30f3)
 
 ## See also
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -261,3 +261,4 @@ markdown_extensions:
   - codehilite(linenums=true)
   - toc(permalink=Link)
   - pymdownx.details
+  - pymdownx.superfences


### PR DESCRIPTION
This type of nesting doesn't work in Python-Markdown and hence in
MkDocs. See https://github.com/mkdocs/mkdocs/issues/488 and
https://github.com/Python-Markdown/markdown/issues/53

Solved by activating the SuperFences PyMdown extension which fortunately
is already included in MkDocs.

Breakage happened in the new translation docs added in 792e127a.

Also:

* Add instructions to edit `griffin/griffin.c`
* Add a section about text encoding ot be used for translation files
* Add link to a new example commit