### PR TITLE
Update ppsspp.md: Change netplay to unsupported

### DIFF
--- a/docs/library/ppsspp.md
+++ b/docs/library/ppsspp.md
@@ -120,7 +120,7 @@ RetroArch-level settings or features that the PPSSPP core respects.
 | Saves             | ✔         |
 | States            | ✔         |
 | Rewind            | ✔         |
-| Netplay           | ✔ (not Ad-Hoc emulation) |
+| Netplay           | ✕         |
 | Core Options      | ✔         |
 | RetroAchievements | ✕         |
 | RetroArch Cheats  | ✕         |


### PR DESCRIPTION
When documenting netplay support, I've been working with the assumption that every core with savestate support (serialization) technically has netplay support.

This approach is problematic. End-users look at the documentation without knowing the difference between state-based netplay and ad-hoc/link-cable netplay

To prevent further confusion with the PPSSPP doc, I'm changing the netplay entry to unsupported.