### PR TITLE
Add Gearsystem documentation

### DIFF
--- a/docs/guides/retroachievements.md
+++ b/docs/guides/retroachievements.md
@@ -70,6 +70,7 @@ You can also check the progress of your friends and add comments on their trophi
 
 | Core                                                           | Supported |
 |----------------------------------------------------------------|:---------:|
+| [Gearsystem](https://github.com/drhelius/Gearsystem)           | ✔         |
 | [Genesis Plus GX](https://github.com/libretro/Genesis-Plus-GX) | ✔         |
 | [Picodrive](https://github.com/libretro/picodrive)             | ✔         |
 | [Emux SMS](https://github.com/libretro/emux)                   | ✕         |

--- a/docs/guides/softpatching.md
+++ b/docs/guides/softpatching.md
@@ -55,3 +55,9 @@ RetroArch currently supports UPS, IPS and BPS patching formats. If you load `rom
 | [FCEUmm](../library/fceumm.md)           | ✔         |
 | [Nestopia UE](../library/nestopia_ue.md) | ✔         |
 | [QuickNES](../library/quicknes.md)       | ✔         |
+
+### Master System / MegaDrive - Genesis
+
+| Core                                                           | Supported |
+|----------------------------------------------------------------|:---------:|
+| [Gearsystem](https://github.com/drhelius/Gearsystem)           | ✔         |

--- a/docs/library/gearsystem.md
+++ b/docs/library/gearsystem.md
@@ -2,16 +2,15 @@
 
 ## Background
 
-Gearsystem is a Sega Master System / Game Gear emulator written in C++ that runs on iOS, Raspberry Pi, Mac, Windows and Linux.
+Gearsystem is an open source, multi-platform, Sega Master System / Game Gear emulator written in C++.
 
-- Highly accurate Z80 core, including undocumented opcodes and behaviour like R and MEMPTR registers.
+- Highly accurate Z80 core, including undocumented opcodes and behaviour.
 - Multi-Mapper support: SEGA, Codemasters, and ROM only cartridges.
-- External RAM support with save files.
 - Automatic region detection: NTSC-JAP, NTSC-USA, PAL-EUR.
+- Internal database for rom detection
 - Highly accurate VDP emulation including timing and SMS2 only 224 mode support.
-- Internal database for rom detection.
 - Audio emulation using SDL Audio and Sms_Snd_Emu library.
-- Saves battery powered RAM cartridges to file.
+- Battery powered RAM save support.
 - Save states.
 - Runs on Windows, Linux, Mac OS X, Raspberry Pi, iOS and as a libretro core (RetroArch).
 
@@ -54,7 +53,7 @@ Frontend-level settings or features that the Gearsystem core respects.
 | Saves             | ✔         |
 | States            | ✔         |
 | Rewind            | ✔         |
-| Netplay           | ✔         |
+| Netplay           | ✕         |
 | Core Options      | ✕         |
 | RetroAchievements | ✔         |
 | RetroArch Cheats  | ✕         |

--- a/docs/library/gearsystem.md
+++ b/docs/library/gearsystem.md
@@ -1,0 +1,141 @@
+# Sega - MS/GG (Gearsystem)
+
+## Background
+
+Gearsystem is a Sega Master System / Game Gear emulator written in C++ that runs on iOS, Raspberry Pi, Mac, Windows and Linux.
+
+- Highly accurate Z80 core, including undocumented opcodes and behaviour like R and MEMPTR registers.
+- Multi-Mapper support: SEGA, Codemasters, and ROM only cartridges.
+- External RAM support with save files.
+- Automatic region detection: NTSC-JAP, NTSC-USA, PAL-EUR.
+- Highly accurate VDP emulation including timing and SMS2 only 224 mode support.
+- Internal database for rom detection.
+- Audio emulation using SDL Audio and Sms_Snd_Emu library.
+- Saves battery powered RAM cartridges to file.
+- Save states.
+- Runs on Windows, Linux, Mac OS X, Raspberry Pi, iOS and as a libretro core (RetroArch).
+
+The Gearsystem core has been authored by
+
+- Ignacio Sanchez
+
+The Gearsystem core is licensed under
+
+- [GPLv3](https://github.com/drhelius/Gearsystem/blob/master/LICENSE) 
+
+A summary of the licenses behind RetroArch and its cores have found [here](https://docs.libretro.com/tech/licenses/).
+
+## BIOS
+
+Not required.
+
+## Extensions
+
+Content that can be loaded by the Gearsystem core have the following file extensions:
+
+- .sms
+- .gg
+- .bin
+- .rom
+
+RetroArch database(s) that are associated with the Gearsystem core:
+
+- [Sega - Game Gear](https://github.com/libretro/libretro-database/blob/master/rdb/Sega%20-%20Game%20Gear.rdb)
+- [Sega - Master System - Mark III](https://github.com/libretro/libretro-database/blob/master/rdb/Sega%20-%20Master%20System%20-%20Mark%20III.rdb)
+
+## Features
+
+Frontend-level settings or features that the Gearsystem core respects.
+
+| Feature           | Supported |
+|-------------------|:---------:|
+| Restart           | ✔         |
+| Screenshots       | ✔         |
+| Saves             | ✔         |
+| States            | ✔         |
+| Rewind            | ✔         |
+| Netplay           | ✔         |
+| Core Options      | ✕         |
+| RetroAchievements | ✔         |
+| RetroArch Cheats  | ✕         |
+| Native Cheats     | ✕         |
+| Controls          | ✔         |
+| Remapping         | ✔         |
+| Multi-Mouse       | ✕         |
+| Rumble            | ✕         |
+| Sensors           | ✕         |
+| Camera            | ✕         |
+| Location          | ✕         |
+| Subsystem         | ✕         |
+| [Softpatching](https://docs.libretro.com/guides/softpatching/) | ✔         |
+| Disk Control      | ✕         |
+| Username          | ✕         |
+| Language          | ✕         |
+| Crop Overscan     | ✕         |
+| LEDs              | ✕         |
+
+### Directories
+
+The Gearsystem core's library name is 'Gearsystem'
+
+The Gearsystem core saves/loads to/from these directories.
+
+**Frontend's Save directory**
+
+| File  | Description            |
+|:-----:|:----------------------:|
+| *.srm | Cartridge battery save |
+
+**Frontend's State directory**
+
+| File     | Description |
+|:--------:|:-----------:|
+| *.state# | State       |
+
+### Geometry and timing
+
+- The Gearsystem core's core provided FPS is 60
+- The Gearsystem core's core provided sample rate is 44100 Hz
+- The Gearsystem core's base width is (Base width)
+- The Gearsystem core's base height is (Base height)
+- The Gearsystem core's max width is (Max width)
+- The Gearsystem core's max height is (Max height)
+- The Gearsystem core's core provided aspect ratio is (Ratio)
+
+### Joypad
+
+![](../image/controller/gg.png)
+
+![](../image/controller/sms.png)
+
+| User 1 input descriptors | RetroPad Inputs                                |
+|--------------------------|------------------------------------------------|
+| 1                        | ![](../image/retropad/retro_b.png)             |
+| Start                    | ![](../image/retropad/retro_start.png)         |
+| Up                       | ![](../image/retropad/retro_dpad_up.png)       |
+| Down                     | ![](../image/retropad/retro_dpad_down.png)     |
+| Left                     | ![](../image/retropad/retro_dpad_left.png)     |
+| Right                    | ![](../image/retropad/retro_dpad_right.png)    |
+| 2                        | ![](../image/retropad/retro_a.png)             |
+
+## Compatibility
+
+- [Gearsystem Accuracy Tests](https://github.com/drhelius/Gearsystem#accuracy-tests)
+
+## External Links
+
+- [Official Gearsystem Repository](https://github.com/drhelius/Gearsystem)
+- [Libretro Gearsystem Core info file](https://github.com/libretro/libretro-super/blob/master/dist/info/gearsystem_libretro.info)
+- [Report Libretro Gearsystem Core Issues Here](https://github.com/drhelius/Gearsystem/issues)
+
+### See also
+
+#### Sega - Game Gear
+
+- [Sega - MS/GG/MD/CD (Genesis Plus GX)](https://docs.libretro.com/library/genesis_plus_gx/)
+
+#### Sega - Master System - Mark III
+
+- [Sega - Master System (Emux SMS)](https://docs.libretro.com/library/emux_sms/)
+- [Sega - MS/GG/MD/CD (Genesis Plus GX)](https://docs.libretro.com/library/genesis_plus_gx/)
+- [Sega - MS/MD/CD/32X (PicoDrive)](https://docs.libretro.com/library/picodrive/)

--- a/docs/library/gearsystem.md
+++ b/docs/library/gearsystem.md
@@ -4,7 +4,7 @@
 
 Gearsystem is an open source, multi-platform, Sega Master System / Game Gear emulator written in C++.
 
-- Highly accurate Z80 core, including undocumented opcodes and behaviour.
+- Highly accurate Z80 core, including undocumented opcodes and behaviour like R and MEMPTR registers.
 - Multi-Mapper support: SEGA, Codemasters, and ROM only cartridges.
 - Automatic region detection: NTSC-JAP, NTSC-USA, PAL-EUR.
 - Internal database for rom detection

--- a/docs/meta/core_list.md
+++ b/docs/meta/core_list.md
@@ -57,6 +57,7 @@
 - Gambatte
 - Game Music Emu
 - Gearboy
+- Gearsystem
 - Genesis Plus GX
 - gpSP
 - GW

--- a/docs/meta/see_also.md
+++ b/docs/meta/see_also.md
@@ -330,12 +330,14 @@
 #### Sega - Game Gear
 
 - [Sega - MS/GG/MD/CD (Genesis Plus GX)](https://docs.libretro.com/library/genesis_plus_gx/)
+- [Sega - MS/GG (Gearsystem)](https://docs.libretro.com/library/gearsystem/)
 
 #### Sega - Master System - Mark III
 
 - [Sega - Master System (Emux SMS)](https://docs.libretro.com/library/emux_sms/)
 - [Sega - MS/GG/MD/CD (Genesis Plus GX)](https://docs.libretro.com/library/genesis_plus_gx/)
 - [Sega - MS/MD/CD/32X (PicoDrive)](https://docs.libretro.com/library/picodrive/)
+- [Sega - MS/GG (Gearsystem)](https://docs.libretro.com/library/gearsystem/)
 
 #### Sega - Mega Drive - Genesis
 

--- a/docs/meta/todo.md
+++ b/docs/meta/todo.md
@@ -322,6 +322,8 @@
 
 ### [✔] Gearboy
 
+### [〰️] Gearsystem
+
 ### [〰️] Genesis Plus GX
 
 - Complete BIOS md5

--- a/docs/tech/licenses.md
+++ b/docs/tech/licenses.md
@@ -113,6 +113,7 @@ See below for a summary of the licenses behind RetroArch and its cores:
 | [Gambatte](../library/gambatte.md)                                               | [GPLv2](https://github.com/libretro/gambatte-libretro/blob/master/COPYING)                |                |
 | [Game Music Emu](../library/game_music_emu.md)            		           | [GPLv3](https://github.com/libretro/libretro-gme/blob/master/LICENSE)                     |                |
 | [Gearboy](../library/gearboy.md)                                                 | [GPLv3](https://github.com/libretro/Gearboy/blob/master/LICENSE)                          |                |
+| [Gearsystem](../library/gearsystem.md)                                           | [GPLv3](https://github.com/drhelius/Gearsystem/blob/master/LICENSE)                       |                |
 | [Genesis Plus GX](../library/genesis_plus_gx.md)          		           | [Non-commercial](https://github.com/libretro/Genesis-Plus-GX/blob/master/LICENSE.txt)     | Non-commercial |
 | [gpSP](../library/gpsp.md)                                                       | [GPLv2](https://github.com/libretro/gpsp/blob/master/COPYING)                             |                |
 | [GW](../library/gw.md)                                                           | [zlib](https://github.com/libretro/gw-libretro/blob/master/LICENSE)                       |                |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -184,6 +184,7 @@ pages:
         - 'Sega - Dreamcast (Redream)': 'library/redream.md'
         - 'Sega - Dreamcast (Reicast)': 'library/reicast.md'
         - 'Sega - Master System (Emux SMS)': 'library/emux_sms.md'
+        - 'Sega - MS/GG (Gearsystem)': 'library/gearsystem.md'
         - 'Sega - MS/GG/MD/CD (Genesis Plus GX)': 'library/genesis_plus_gx.md'
         - 'Sega - MS/MD/CD/32X (PicoDrive)': 'library/picodrive.md'
         - 'Sega - Saturn (Beetle Saturn)': 'library/beetle_saturn.md'


### PR DESCRIPTION
Adds documentation for the new Gearsystem core with help from drhelius

https://github.com/libretro/libretro-super/commit/2b96bab99983843479fa2e717d680f26d4838cc4
https://github.com/drhelius/Gearsystem/issues/10

**Document(s) added**

- docs/library/gearsystem.md

    Added a Gearsystem core doc

**Document(s) modified**

- docs/guides/retroachievements.md

    Gearsystem supports RetroAchievements

- docs/guides/softpatching.md

    Gearsystem supports softpatching

- docs/meta/core_list.md

    Added Gearsystem to list of libretro cores

- docs/meta/see_also.md

    Added Gearsystem to list of libretro cores that share databases with each other

- docs/meta/todo.md

    Added Gearsystem section to the documentation to-do list

- docs/tech/licenses.md

    Added Gearsystem license info

- mkdocs.yml 

    Added Gearsystem core doc to mkdocs.yml tree
