### PR TITLE
Change Netplay to unsupported in remaining GB/GBA/N64/PSX core docs

### DIFF
--- a/docs/library/beetle_gba.md
+++ b/docs/library/beetle_gba.md
@@ -50,7 +50,7 @@ Frontend-level settings or features that the Beetle GBA core respects.
 | Saves             | ✔         |
 | States            | ✔         |
 | Rewind            | ✔         |
-| Netplay           | ✔ (not link-cable emulation)         |
+| Netplay           | ✕         |
 | Core Options      | ✔         |
 | RetroAchievements | ✔         |
 | RetroArch Cheats  | ✕         |

--- a/docs/library/beetle_psx.md
+++ b/docs/library/beetle_psx.md
@@ -63,7 +63,7 @@ Frontend-level settings or features that the Beetle PSX core respects.
 | Saves             | ✔         |
 | States            | ✔         |
 | Rewind            | ✔         |
-| Netplay (State based) | ✔         |
+| Netplay           | ✕         |
 | Core Options      | ✔         |
 | RetroAchievements | ✕         |
 | Cheats (Cheats menu) | ✔         |

--- a/docs/library/beetle_psx_hw.md
+++ b/docs/library/beetle_psx_hw.md
@@ -63,7 +63,7 @@ Frontend-level settings or features that the Beetle PSX HW core respects.
 | Saves             | ✔         |
 | States            | ✔         |
 | Rewind            | ✔         |
-| Netplay (State based) | ✔         |
+| Netplay           | ✕         |
 | Core Options      | ✔         |
 | RetroAchievements | ✕         |
 | Cheats (Cheats menu) | ✔         |

--- a/docs/library/gambatte.md
+++ b/docs/library/gambatte.md
@@ -54,7 +54,7 @@ Frontend-level settings or features that the Gambatte core respects.
 | Saves             | ✔         |
 | States            | ✔         |
 | Rewind            | ✔         |
-| Netplay           | ✔ (not link-cable emulation)         |
+| Netplay           | ✕         |
 | Core Options      | ✔         |
 | RetroAchievements | ✔         |
 | RetroArch Cheats  | ✔         |

--- a/docs/library/gpsp.md
+++ b/docs/library/gpsp.md
@@ -48,7 +48,7 @@ Frontend-level settings or features that the gpSP core respects.
 | Saves             | ✔         |
 | States            | ✔         |
 | Rewind            | ✔         |
-| Netplay           | ✔ (not link-cable emulation)         |
+| Netplay           | ✕         |
 | Core Options      | ✕         |
 | RetroAchievements | ✕         |
 | RetroArch Cheats  | ✕         |

--- a/docs/library/meteor.md
+++ b/docs/library/meteor.md
@@ -39,7 +39,7 @@ Frontend-level settings or features that the Meteor core respects.
 | Saves             | ✔         |
 | States            | ✔         |
 | Rewind            | ✔         |
-| Netplay           | ✔ (not link-cable emulation) |
+| Netplay           | ✕         |
 | Core Options      | ✔         |
 | RetroAchievements | ✕         |
 | RetroArch Cheats  | ✕         |

--- a/docs/library/mgba.md
+++ b/docs/library/mgba.md
@@ -54,7 +54,7 @@ Frontend-level settings or features that the mGBA core respects.
 | Saves             | ✔         |
 | States            | ✔         |
 | Rewind            | ✔         |
-| Netplay (State based) | ✔ (not link-cable emulation)        |
+| Netplay           | ✕         |
 | Core Options      | ✔         |
 | RetroAchievements | ✔ (GBA only)        |
 | Cheats (Cheats menu) | ✔         |

--- a/docs/library/mupen64plus.md
+++ b/docs/library/mupen64plus.md
@@ -105,7 +105,7 @@ RetroArch-level settings or features that the Mupen64Plus core respects.
 | Saves             | ✔         |
 | States            | ✔         |
 | Rewind            | ✔         |
-| Netplay           | ✔         |
+| Netplay           | ✕         |
 | Core Options      | ✔         |
 | RetroAchievements | ✔         |
 | RetroArch Cheats  | ✔         |

--- a/docs/library/pcsx_rearmed.md
+++ b/docs/library/pcsx_rearmed.md
@@ -112,7 +112,7 @@ RetroArch-level settings or features that the PCSX ReARMed core respects.
 | Saves             | ✔         |
 | States            | ✔         |
 | Rewind            | ✔         |
-| Netplay           | ✔         |
+| Netplay           | ✕         |
 | Core Options      | ✔         |
 | RetroAchievements | ✕         |
 | RetroArch Cheats  | ✔         |

--- a/docs/library/vba_m.md
+++ b/docs/library/vba_m.md
@@ -40,7 +40,7 @@ Frontend-level settings or features that the VBA-M core respects.
 | Saves             | ✔         |
 | States            | ✔         |
 | Rewind            | ✔         |
-| Netplay           | ✔ (not link-cable emulation)         |
+| Netplay           | ✕         |
 | Core Options      | ✔         |
 | RetroAchievements | ✔         |
 | RetroArch Cheats  | ✔         |

--- a/docs/library/vba_next.md
+++ b/docs/library/vba_next.md
@@ -52,7 +52,7 @@ Frontend-level settings or features that the VBA Next core respects.
 | Saves             | ✔         |
 | States            | ✔         |
 | Rewind            | ✔         |
-| Netplay           | ✔ (not link-cable emulation)         |
+| Netplay           | ✕         |
 | Core Options      | ✔         |
 | RetroAchievements | ✔         |
 | RetroArch Cheats  | ✕         |


### PR DESCRIPTION
When documenting netplay support, I've been working with the assumption that every core with savestate support (serialization) technically has netplay support.

This approach is problematic. End-users look at the documentation without knowing the difference between state-based netplay and ad-hoc/link-cable netplay

To prevent furthur confusion, I'm changing Netplay to unsupported in the rest of the GB/GBA/N64/PSX docs.