### PR TITLE
 Update retroachievements.md, mesen.md

### DIFF
--- a/docs/guides/retroachievements.md
+++ b/docs/guides/retroachievements.md
@@ -65,10 +65,10 @@ You can also check the progress of your friends and add comments on their trophi
 
 | Core                                                  | Supported | Notes |
 |-------------------------------------------------------|:---------:|-------|
-| [Mesen](https://github.com/SourMesen/Mesen)           | ✕         | |
+| [Mesen](https://github.com/SourMesen/Mesen)           | ✕         | [**Achievements are not fully supported yet**](https://github.com/SourMesen/Mesen/issues/341) |
 | [FCEUmm](https://github.com/libretro/libretro-fceumm) | ✔         | |
 | [QuickNES](https://github.com/libretro/QuickNES_Core) | ✔         | On Android has a [known issue](https://github.com/libretro/RetroArch/issues/3973) |
-| [Nestopia UE](https://github.com/libretro/nestopia)   | ✕         | |
+| [Nestopia UE](https://github.com/libretro/nestopia)   | ✕         | [**Achievements are not fully supported yet**](https://github.com/libretro/docs/pull/10) |
 | [bnes](https://github.com/libretro/bnes-libretro)     | ✕         | |
 | [Emux NES](https://github.com/libretro/emux)          | ✕         | |
 

--- a/docs/guides/retroachievements.md
+++ b/docs/guides/retroachievements.md
@@ -65,7 +65,7 @@ You can also check the progress of your friends and add comments on their trophi
 
 | Core                                                  | Supported | Notes |
 |-------------------------------------------------------|:---------:|-------|
-| [Mesen](https://github.com/SourMesen/Mesen)           | ✔         | |
+| [Mesen](https://github.com/SourMesen/Mesen)           | ✕         | |
 | [FCEUmm](https://github.com/libretro/libretro-fceumm) | ✔         | |
 | [QuickNES](https://github.com/libretro/QuickNES_Core) | ✔         | On Android has a [known issue](https://github.com/libretro/RetroArch/issues/3973) |
 | [Nestopia UE](https://github.com/libretro/nestopia)   | ✕         | |

--- a/docs/library/mesen.md
+++ b/docs/library/mesen.md
@@ -63,7 +63,7 @@ Frontend-level settings or features that the Mesen core respects.
 | Rewind            | ✔         |
 | Netplay           | ✔         |
 | Core Options      | ✔         |
-| RetroAchievements | ✔         |
+| RetroAchievements | ✕         |
 | RetroArch Cheats  | ✔         |
 | Native Cheats     | ✕         |
 | Controls          | ✔         |


### PR DESCRIPTION
- Mesen doesn't fully support RetroAchievements. It has the same issue as Nestopia UE.

- Make it clear that Nestopia UE and Mesen don't fully support retroachievements yet.

