### PR TITLE
Update beetle_cygne.md

### DIFF
--- a/docs/library/beetle_cygne.md
+++ b/docs/library/beetle_cygne.md
@@ -23,6 +23,7 @@ Content that can be loaded by the Beetle Cygne core have the following file exte
 
 - .ws
 - .wsc
+- .pc2 (Benesse Pocket Challenge v2 files)
 
 ## Databases
 


### PR DESCRIPTION
Added .pc2 file extension to supported extensions. This core also emulates the Benesse Pocket Challenge v2 which uses this file extension.