### PR TITLE
PCSX ReARMed: Update NeGcon Documentation

### DIFF
--- a/docs/library/pcsx_rearmed.md
+++ b/docs/library/pcsx_rearmed.md
@@ -460,7 +460,7 @@ Activating multitap support in compatible games can be configured by the ['Multi
 | ![](../image/retropad/retro_left_stick.png) X  | Left Analog X                |             | Left Analog X  | Twist                           |
 | ![](../image/retropad/retro_left_stick.png) Y  | Left Analog Y                |             | Left Analog Y  |                                 |
 | ![](../image/retropad/retro_right_stick.png) X | Right Analog X               |             | Right Analog X |                                 |
-| ![](../image/retropad/retro_right_stick.png) Y | Right Analog Y               |             | Right Analog Y |                                 |
+| ![](../image/retropad/retro_right_stick.png) Y | Right Analog Y               |             | Right Analog Y | Up: Analog Button I / Down: Analog Button II |
 
 ## Compatibility
 


### PR DESCRIPTION
This teeny tiny pull request just updates the PCSX ReARMed documentation with the new neGcon input mapping added in pcsx_rearmed [PR #195](https://github.com/libretro/pcsx_rearmed/pull/195).