### PR TITLE
remove vista references from windows msys2 compile doc

### DIFF
--- a/docs/compilation/windows.md
+++ b/docs/compilation/windows.md
@@ -1,7 +1,7 @@
-# Windows (Vista and later) Compilation / Development Guide
+# Windows 7 and later compilation and development guide
 
 !!! Warning
-    The MinGW toolchain we use in this guide no longer supports targeting Windows XP. Programs compiled with it will fail to start with it.
+    The MinGW toolchain we use in this guide no longer supports targeting Windows Vista or ealier.
     Please refer to one of the MSVC guides for how to target older Windows versions with Visual Studio.
 
 ## Environment configuration

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -244,7 +244,7 @@ pages:
           - Windows XP and later (MSVC2010):
             - 'MSVC Commandline': 'compilation/windowsXP-msvc-cmdline.md'
             - 'MSVC IDE': 'compilation/windowsXP.md'
-          - 'Windows Vista and later (MSYS2)': 'compilation/windows.md'
+          - 'Windows 7 and later (MSYS2)': 'compilation/windows.md'
         - Nintendo:
           - 'Nintendo 3DS': 'compilation/3ds.md'
           - 'Nintendo GameCube': 'compilation/gamecube.md'


### PR DESCRIPTION
If I understand correctly from discussions on discord, the msys2 environment now has a minimum requirement of Windows 7, so this PR would update the docs to reflect that.