### PR TITLE
rename "Multi-System Cores" to "Arcade Cores" in TOC

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -41,6 +41,10 @@ pages:
       - Amstrad Cores:
         - 'Amstrad - CPC (Caprice32)': 'library/caprice32.md'
         - 'Amstrad - CPC (CrocoDS)': 'library/crocods.md'
+      - Arcade Cores:
+        - 'Arcade (MAME 2003)': 'library/mame_2003.md'
+        - 'Arcade (MAME 2003-Plus)': 'library/mame2003_plus.md'        
+        - 'Arcade (MAME 2010)': 'library/mame_2010.md'
       - Atari Cores:      
         - 'Atari - 2600 (Stella)': 'library/stella.md'
         - 'Atari - 7800 (ProSystem)': 'library/prosystem.md'
@@ -71,10 +75,6 @@ pages:
         - 'Game Music Emu': 'library/game_music_emu.md'
         - 'Imageviewer': 'library/imageviewer.md'
         - 'PocketCDG': 'library/pocketcdg.md'
-      - Multi System Cores:
-        - 'Arcade (MAME 2003)': 'library/mame_2003.md'
-        - 'Arcade (MAME 2003-Plus)': 'library/mame2003_plus.md'        
-        - 'Arcade (MAME 2010)': 'library/mame_2010.md'
       - Misc Cores:
         - '3D Engine': 'library/3d_engine.md'
         - 'The 3DO Company - 3DO (4DO)': 'library/4do.md'


### PR DESCRIPTION
At the moment there are only MAME 2003 and MAME 2010 cores listed in the "Multi-System" section of the core list. I think that users are more naturally going to look for these under arcade cores.

There is a precedent for listing the same core doc in more than one part of the core list, so I'd also be open to the idea of having both an "Arcade Cores" section **and** and "Multi-System" section for things like FBA, MESS, and current MAME.