### PR TITLE
organize development docs TOC / add git file format directives

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,21 @@
+# EditorConfig is awesome: http://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+
+# Tab indentation (no size specified)
+[Makefile]
+indent_style = tab
+
+# Matches multiple files with brace expansion notation
+# Set default charset
+[*.{c,h}]
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,16 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text=auto
+
+# Declare files that will always have LF Unix-style line endings on checkout.
+*.c text eol=lf
+*.h text eol=lf
+*.in text eol=lf
+*.md text eol=lf
+*.txt text eol=lf
+
+# Denote all files that are truly binary and should not be modified.
+*.png binary
+*.jpg binary
+*.gif binary
+*.zip binary
+*.pdf binary

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -214,6 +214,9 @@ pages:
     - Contributing:
       - 'How to Contribute to the Docs': 'guides/how-to-contribute.md'
   - For Developers:
+    - Libretro API and Ecosystem:
+      - 'Libretro API Overview': 'specs/api.md'
+      - 'RetroPad Input API': 'specs/retropad.md'
     - Compilation:
       - Cores:
         - Nintendo Cores:
@@ -255,18 +258,14 @@ pages:
           - 'PlayStation2': 'compilation/ps2.md'
           - 'PlayStation Portable': 'compilation/psp.md'
           - 'PlayStation Vita/TV': 'compilation/psvita.md'
-    - Meta:
-      - 'Core List': 'meta/core_list.md'
-      - 'To Do': 'meta/todo.md'
-      - 'Core Template': 'meta/core_template.md'
-      - 'See Also': 'meta/see_also.md'
     - RetroArch Development:
       - 'Debugging': 'tech/debugging.md'
       - 'Adding Menu Entries': 'tech/new-menu-options.md'
+      - 'Input Overlays': 'specs/overlay.md'
       - 'Licenses': 'tech/licenses.md'
       - 'MSVC Runtimes': 'tech/msvc-runtime-versions.md'
       - 'Adding Translations': 'tech/new-translations.md'
-      - Protocols:
+      - Network Protocols:
         - 'Netplay': 'tech/netplay.md'
         - 'Network Control Interface': 'tech/network-control-interface.md'
     - Core Development:
@@ -276,10 +275,11 @@ pages:
     - Shader Development:
       - 'Shader Development Overview': 'specs/shader.md'
       - 'Content-Aware Shaders': 'tech/content-aware-shaders.md'
-    - Specifications:
-      - 'Libretro': 'specs/api.md'
-      - 'RetroPad': 'specs/retropad.md'
-      - 'Overlays': 'specs/overlay.md'
+    - Documentation Meta:
+      - 'Core List': 'meta/core_list.md'
+      - 'To Do': 'meta/todo.md'
+      - 'Core Template': 'meta/core_template.md'
+      - 'See Also': 'meta/see_also.md'
 extra:
   version: '0.1.0'
   font:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -216,7 +216,7 @@ pages:
   - For Developers:
     - Libretro API and Ecosystem:
       - 'Libretro API Overview': 'specs/api.md'
-      - 'RetroPad Input API': 'specs/retropad.md'
+      - 'Libretro Input API': 'specs/retropad.md'
     - Compilation:
       - Cores:
         - Nintendo Cores:


### PR DESCRIPTION
This PR is the latest in my "development doc upgrade" project.

Once it's clear we have a good consensus TOC I will do a little more editing and refactoring before hopefully I'll see the end of the possibilities for improving this and move on :)

I should point out that this PR will also set some git directives intended to make it harder for me to accidentally commit Windows EOL files in the future.