### PR TITLE
add "nl2br" mkdocs extension to conform with github markdown

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -298,6 +298,7 @@ markdown_extensions:
   - markdown.extensions.admonition
   - markdown.extensions.codehilite:
       linenums: true
+  - markdown.extensions.nl2br
   - markdown.extensions.toc:
       permalink: true
   - pymdownx.details


### PR DESCRIPTION
One of the things that's been tedious about working on the formatting is that by default GitHub parses Markdown slightly differently than mkdocs does by default. The consequence for me is that headers and lists that look fine in GitHub preview don't look the same once they're built as HTML.

I request that adding this `nl2br` extension which seems designed for this specific purpose: https://python-markdown.github.io/extensions/nl2br/