### PR TITLE
libretro overview: fix link to frontends; add libretro distributions

### DIFF
--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -19,8 +19,7 @@ The libretro API consists of several functions outlined in libretro.h, found in 
 [A growing list of libretro frontends](../tech/frontends.md) is available, reflecting a variety of host systems and use cases. RetroArch is the libretro "reference frontend" and is available across a wide range of host platforms.
 
 ## Libretro-powered operating systems
-
-Lakka, based on LibreELEC, is our Libretro's reference operating system distribution. Below is a partial list of external distributions that also use libretro/RetroArch as part of their backend technology:
+Lakka, based on LibreELEC, is Libretro's reference operating system distribution. Below is a partial list of external distributions that also use libretro/RetroArch as part of their backend technology:
   
   * [batocera.linux](http://batocera-linux.xorhub.com/)
   * [RetroPie](http://retropie.org.uk/)

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -19,7 +19,7 @@ The libretro API consists of several functions outlined in libretro.h, found in 
 [A growing list of libretro frontends](../tech/frontends.md) is available, reflecting a variety of host systems and use cases. RetroArch is the libretro "reference frontend" and is available across a wide range of host platforms.
 
 ## Libretro-powered operating systems
-Lakka, based on LibreELEC, is Libretro's reference operating system distribution. Below is a partial list of external distributions that also use libretro/RetroArch as part of their backend technology:
+[Lakka](http://www.lakka.tv/), based on LibreELEC, is Libretro's reference operating system distribution. Below is a partial list of external distributions that also use libretro/RetroArch as part of their backend technology:
   
   * [batocera.linux](http://batocera-linux.xorhub.com/)
   * [RetroPie](http://retropie.org.uk/)

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -10,17 +10,18 @@ When you choose to use the libretro API, your program gets turned into a single 
     Libretro is an open specification that is 100% free to implement, with no licensing fees or strings attached. Our reference frontend is RetroArch. The two projects are not the same, and this is reflected in the licensing. RetroArch is licensed via GPLv3 whereas the libretro API is a MIT-licensed API.
 
 ## libretro.h
-
 The libretro API consists of several functions outlined in libretro.h, found in the RetroArch source package. The API header is compatible with C99 and C++. From C99, the bool type and `<stdint.h>` are used. The latest version of this file can be found [in `libretro-common`](https://github.com/libretro/RetroArch/blob/master/libretro-common/include/libretro.h).
 
-
 ## Libretro core development
-
-
 [Visit the overview on libretro core development](developing-cores.md).
 
-
 ## Libretro frontend development
+[A growing list of libretro frontends](../tech/frontends.md) is available, reflecting a variety of host systems and use cases. RetroArch is the libretro "reference frontend" and is available across a wide range of host platforms.
 
-[A growing list of libretro frontends](frontends.md) is available, reflecting a variety of host systems and use cases. RetroArch is the libretro "reference frontend" and is available across a wide range of host platforms.
+## Libretro-powered operating systems
 
+Lakka, based on LibreELEC, is our Libretro's reference operating system distribution. Below is a partial list of external distributions that also use libretro/RetroArch as part of their backend technology:
+  
+  * [batocera.linux](http://batocera-linux.xorhub.com/)
+  * [RetroPie](http://retropie.org.uk/)
+  * [Recalbox](http://recalbox.com/)


### PR DESCRIPTION
Fixes a link and ports over a missing section from the analogous page here: https://www.libretro.com/index.php/powered-by-libretro/