### PR TITLE
Update Theodore doc

### DIFF
--- a/docs/library/bios.md
+++ b/docs/library/bios.md
@@ -92,6 +92,6 @@ SNES/Super Famicom            | bsnes-mercury Perf | [BIOS information](https://
 SNES/Super Famicom            | nSide Balanced     | [BIOS information](https://docs.libretro.com/library/nside_balanced/#bios)
 SNES/Super Famicom            | higan Accuracy     | [BIOS information](https://docs.libretro.com/library/higan_accuracy/#bios)
 ST/STE/TT/Falcon              | Hatari             | [BIOS information](https://docs.libretro.com/library/hatari/#bios)
-Thomson - TO8D                | Theodore           | [BIOS information](https://docs.libretro.com/library/theodore/#bios)
+Thomson - MO/TO               | Theodore           | [BIOS information](https://docs.libretro.com/library/theodore/#bios)
 Vectrex                       | vecx               | [BIOS information](https://docs.libretro.com/library/vecx/#bios)
 ZX Spectrum                   | Fuse               | [BIOS information](https://docs.libretro.com/library/fuse/#bios)

--- a/docs/library/theodore.md
+++ b/docs/library/theodore.md
@@ -3,7 +3,7 @@
 ## Background
 
 Theodore is a Thomson MO/TO system emulator based on Daniel Coulom's DCTO8D/DCTO9P/DCMO5 emulators. [Thomson MO/TO](https://en.wikipedia.org/wiki/Thomson_computers) is a family of 8-bit home computers produced by French company Thomson SA between 1982 and 1989.
-At the time of this writing, Theodore emulates the following versions of the MO/TO family: TO8, TO8D, TO9, TO9+, MO5.
+At the time of this writing, Theodore emulates the following models of the MO/TO family: TO8, TO8D, TO9, TO9+, MO5.
 
 The Theodore core has been authored by
 
@@ -34,6 +34,10 @@ Content that can be loaded by the Theodore core have the following file extensio
 - .m7 (cartridge)
 - .m5 (cartridge)
 
+RetroArch database(s) that are associated with the Theodore core:
+
+- [Thomson - MOTO](https://github.com/libretro/libretro-database/blob/master/rdb/Thomson%20-%20MOTO.rdb)
+
 ## Features
 
 Frontend-level settings or features that the Theodore core respects.
@@ -43,12 +47,12 @@ Frontend-level settings or features that the Theodore core respects.
 | Restart           | ✔         |
 | Saves             | ✔         |
 | States            | ✔         |
-| Rewind            | ✕         |
-| Netplay           | -         |
+| Rewind            | ✔         |
+| Netplay           | ✔         |
 | Core Options      | ✔         |
 | RetroAchievements | ✕         |
 | RetroArch Cheats  | ✔         |
-| Native Cheats     | -         |
+| Native Cheats     | ✕         |
 | Controls          | -         |
 | Remapping         | -         |
 | Multi-Mouse       | -         |
@@ -60,9 +64,9 @@ Frontend-level settings or features that the Theodore core respects.
 | [Softpatching](https://docs.libretro.com/guides/softpatching/) | ✕         |
 | Disk Control      | ✕         |
 | Username          | ✕         |
-| Language          | -         |
-| Crop Overscan     | -         |
-| LEDs              | -         |
+| Language          | ✕         |
+| Crop Overscan     | ✕         |
+| LEDs              | ✕         |
 
 ### Directories
 
@@ -86,18 +90,16 @@ shown below.
 
 ![](../image/core/theodore/to8d_os.jpg)
 
-Now it is time to start BASIC 512 that will run the program on the bootable device currently presented. To do that you only have to press the "B" button of your joypad that is conveniently mapped to the "B" key (except for TO9 where the "B" button is mapped to the "D" key to start BASIC 128).
-
-!!! Notes
-        - BASIC 512 works for a vast majority of games.
-        - In case of failure try the 2nd BASIC by pressing "C" key.
-        - When using a cartridge, the "B" button is mapped to the "A" key to start the program on the cartridge (entry not shown here).
+When the "Thomson model" core option is set to "Auto" (default value), the core tries to autodetect the Thomson model to emulate based on the name of the content file, and fallback to TO8 mode if it cannot.
+The "Start" button of the controller can be used to start the game. The core will then make an "educated guess" to start the game (cf. [Theodore's README file](https://github.com/Zlika/theodore/blob/master/README.md#video_game-gamepad-mapping-of-the-buttons) for more info about it).
 
 ## Core options
 
 The Theodore core has the following option(s) that can be tweaked from the core options menu. The default setting is bolded.
 
-- **Thomson flavor** [theodore_rom]  (**TO8**|TO8D|TO9|TO9+|MO5)
+- **Thomson model** [theodore_rom]  (**Auto**|TO8|TO8D|TO9|TO9+|MO5)
+
+- **Auto run game** [theodore_autorun] (**disabled**|enabled)
 
 - **Floppy write protection** [theodore_floppy_write_protect]  (disabled|**enabled**)
 
@@ -122,12 +124,12 @@ The Theodore core supports the following device type(s) in the controls menu, bo
 | RetroPad Inputs                        | User 1 input descriptors       |
 |----------------------------------------|--------------------------------|
 | ![](../image/retropad/retro_a.png)     | "Fire" button                  |
-| ![](../image/retropad/retro_b.png)     | Autostart program<br>(See: [Usage](#usage)) |
 | ![](../image/retropad/retro_x.png)     | Virtual keyboard: go up        |
 | ![](../image/retropad/retro_y.png)     | Virtual keyboard: go down      |
-| ![](../image/retropad/retro_start.png) | Virtual keyboard: keystroke    |
+| ![](../image/retropad/retro_select.png)| Virtual keyboard: keystroke    |
+| ![](../image/retropad/retro_start.png) | Start program<br>(See: [Usage](#usage)) |
 
-On controllers without Y/X keys, select can also be used to roll the virtual keyboard up. The order of the keys in the virtual keyboard is: digits (0->9) then letters (A->Z) then "Space" then "Enter".
+The order of the keys in the virtual keyboard is: digits (0->9) then letters (A->Z) then "Space" then "Enter".
 
 ## Keyboard
 
@@ -138,7 +140,7 @@ On controllers without Y/X keys, select can also be used to roll the virtual key
 | Keyboard Tab                 | STOP                      |
 | Keyboard Left Control        | CNT                       |
 | Keyboard Caps Lock           | CAPSLOCK                  |
-| Keyboard Left Alt            | ACC                       |
+| Keyboard Backspace           | ACC                       |
 | Keyboard Home                | HOME                      |
 | Keyboard Up                  | UP                        |
 | Keyboard Down                | DOWN                      |
@@ -146,6 +148,7 @@ On controllers without Y/X keys, select can also be used to roll the virtual key
 | Keyboard Left                | LEFT                      |
 | Keyboard Insert              | INS                       |
 | Keyboard Delete              | DEL                       |
+| Keyboard Alt                 | RAZ                       |
 | Keyboard F1                  | F1                        |
 | Keyboard F2                  | F2                        |
 | Keyboard F3                  | F3                        |
@@ -156,17 +159,21 @@ On controllers without Y/X keys, select can also be used to roll the virtual key
 | Keyboard Shift + F3          | F8                        |
 | Keyboard Shift + F4          | F9                        |
 | Keyboard Shift + F5          | F10                       |
+| Keyboard Left Shift          | Shift or Yellow key (MO5) |
+| Keyboard Right Shift         | Shift or BASIC key (MO5)  |
 
 ## Mouse
 
 | RetroMouse Inputs                                     | Theodore Inputs      |
-|-------------------------------------------------------|---------------------------|
-| ![](../image/retromouse/retro_mouse.png) Mouse Cursor | Light pen cursor                         |
-| ![](../image/retromouse/retro_left.png) Mouse 1       | Selection                      |
+|-------------------------------------------------------|----------------------|
+| ![](../image/retromouse/retro_mouse.png) Mouse Cursor | Light pen cursor     |
+| ![](../image/retromouse/retro_left.png) Mouse 1       | Selection            |
 
 ## External Links
 
 - [Libretro Theodore Github Repository](https://github.com/Zlika/theodore)
 - [Report Libretro Theodore Core Issues Here](https://github.com/Zlika/theodore/issues)
 - [Libretro Theodore Core info file](https://github.com/libretro/libretro-super/blob/master/dist/info/theodore_libretro.info)
+- [Libretro Thomson Database](https://github.com/libretro/libretro-database/blob/master/rdb/Thomson%20-%20MOTO.rdb)
+- [Libretro Thomson Thumbnails](https://github.com/libretro-thumbnails/Thomson_-_MOTO)
 - [Official DCTO8D/DCTO9P/DCMO5 Website](http://dcmoto.free.fr/)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -93,7 +93,7 @@ pages:
         - 'Magnavox - Odyssey2 / Phillips Videopac+ (O2EM)': 'library/o2em.md'
         - 'Sharp - X68000 (PX68k)': 'library/px68k.md'
         - 'ScummVM': 'library/scummvm.md'
-        - 'Thomson - TO8 (Theodore)': 'library/theodore.md'
+        - 'Thomson - MO/TO (Theodore)': 'library/theodore.md'
         - 'Uzebox (Uzem)': 'library/uzem.md'
         - 'GCE - Vectrex (vecx)': 'library/vecx.md'
         - 'Bandai - WonderSwan/Color (Beetle Cygne)': 'library/beetle_cygne.md'


### PR DESCRIPTION
Update Theodore doc.
The huge diff of the bios.md file is in fact just a line ending change from CRLF to LF because of a recent change of .gitattributes. The "real" change in this file is in fact the "theodore" line where I changed "Thomson - TO8" into "Thomson - MO/TO".