### PR TITLE
use "edit" button to go straight to github editor

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,7 +1,8 @@
 site_name: Libretro Docs
+site_url: 'http://docs.libretro.com/'
 repo_name: 'libretro/docs'
 repo_url: 'https://github.com/libretro/docs'
-edit_uri: 'tree/master/docs'
+edit_uri: 'edit/master/docs'
 nav:
   - About: 'index.md'
   - For Users:


### PR DESCRIPTION
I'm pretty excited about this new feature as part of our mkdocs configuration. Currently if you click the "pencil" icon at http://docs.libretro.com/ you are taken to the corresponding github page in a 'source view.'

With this PR, you are taken directly into github's 'edit mode' for that particular page in your own fork (which will be created if needed). I think it's pretty neat.