### PR TITLE
refactor Core Library "Misc"/Catch-all category in the TOC

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,7 +6,7 @@ edit_uri: 'edit/master/docs'
 nav:
   - About: 'index.md'
   - For Users:
-    - 'RetroArch: Downloading, Installing, and Updating'
+    - 'RetroArch: Downloading, Installing, and Updating':
       - 'Windows': 'guides/install-windows.md'
       - 'MSVC Runtime Compatibility': 'guides/msvc-runtime-versions.md'
       - 'GNU/Linux': 'guides/install-gnu.md'
@@ -45,15 +45,18 @@ nav:
     - Lakka Documentation: 'http://www.lakka.tv/doc/Home/'
     - Core Library:
       - BIOS Information Hub: 'library/bios.md'
-      - Getting Started with Arcade Emulation: 'guides/arcade-getting-started.md'
-      - Amstrad Cores:
+      - 3DO Emulation:
+        - 'The 3DO Company - 3DO (4DO)': 'library/4do.md'
+        - '3DO Compatibility List': 'library/compatibility/3do.md'
+      - Amstrad Emulation:
         - 'Amstrad - CPC (Caprice32)': 'library/caprice32.md'
         - 'Amstrad - CPC (CrocoDS)': 'library/crocods.md'
-      - Arcade Cores:
+      - Arcade Emulation:
+        - 'Getting Started with Arcade Emulation': 'guides/arcade-getting-started.md'
         - 'Arcade (MAME 2003)': 'library/mame_2003.md'
         - 'Arcade (MAME 2003-Plus)': 'library/mame2003_plus.md'
         - 'Arcade (MAME 2010)': 'library/mame_2010.md'
-      - Atari Cores:
+      - Atari Emulation:
         - 'Atari - Jaguar Compatibility List': 'library/compatibility/jaguar.md'
         - 'Atari - Lynx Compatibility List:': 'library/compatibility/lynx.md'
         - 'Atari - 2600 (Stella)': 'library/stella.md'
@@ -63,52 +66,48 @@ nav:
         - 'Atari - Lynx (Beetle Handy)': 'library/beetle_handy.md'
         - 'Atari - Lynx (Handy)': 'library/handy.md'
         - 'Atari - ST/STE/TT/Falcon (Hatari)': 'library/hatari.md'
-      - Game Cores:
+      - Bandai Emulation:
+        - 'Bandai - WonderSwan/Color (Beetle Cygne)': 'library/beetle_cygne.md'
+        - 'Bandai - Wonderswan Compatibility List': 'library/compatibility/wswan.md'
+      - ColecoVision Emulation:
+        - 'MSX/SVI/ColecoVision/SG-1000 (blueMSX)': 'library/bluemsx.md'
+      - DOS Emulation:
+        - 'DOS (DOSBox)': 'library/dosbox.md'
+      - GCE Emulation:
+        - 'GCE - Vectrex (vecx)': 'library/vecx.md'
+      - Game and Scripting Engines:
         - '2048': 'library/2048.md'
+        - '3D Engine': 'library/3d_engine.md'
         - 'Cave Story (NXEngine)': 'library/nxengine.md'
+        - 'ChaiLove': 'library/chailove.md'
+        - 'CHIP-8 (Emux CHIP-8)': 'library/emux_chip8.md'
         - 'Dinothawr': 'library/dinothawr.md'
         - 'Doom (PrBoom)': 'library/prboom.md'
         - 'Dungeon Crawl Stone Soup': 'library/stone_soup.md'
         - 'Handheld Electronic (GW)': 'library/gw.md'
+        - 'Lua Engine (Lutro)': 'library/lutro.md'
         - 'Minecraft (Craft)': 'library/craft.md'
         - 'Mr.Boom (Bomberman)': 'library/mr_boom.md'
         - 'Quake 1 (TyrQuake)': 'library/tyrquake.md'
         - 'Rick Dangerous (XRick)': 'library/xrick.md'
+        - 'RPG Maker 2000/2003 (EasyRPG)': 'library/easyrpg.md'
+        - 'ScummVM': 'library/scummvm.md'
         - 'The Powder Toy': 'library/the_powder_toy.md'
         - 'Tomb Raider (OpenLara)': 'library/openlara.md'
-      - Internal Cores:
-        - 'Dummy Core': 'library/dummy.md'
-        - 'Remote RetroPad': 'library/remote_retropad.md'
-        - 'Video Processor': 'library/video_processor.md'
+        - 'Uzebox (Uzem)': 'library/uzem.md'
+      - Magnavox Cores:
+        - 'Magnavox - Odyssey2 / Phillips Videopac+ (O2EM)': 'library/o2em.md'
+      - Mattel Emulation:
+        - 'Mattel - Intellivision (FreeIntv)': 'library/freeintv.md'
       - Media Cores:
         - 'FFmpeg': 'library/ffmpeg.md'
         - 'Game Music Emu': 'library/game_music_emu.md'
         - 'Imageviewer': 'library/imageviewer.md'
         - 'PocketCDG': 'library/pocketcdg.md'
-      - Misc Cores:
-        - '3D Engine': 'library/3d_engine.md'
-        - 'The 3DO Company - 3DO (4DO)': 'library/4do.md'
-        - '3DO Compatibility List': 'library/compatibility/3do.md'
-        - 'ChaiLove': 'library/chailove.md'
-        - 'CHIP-8 (Emux CHIP-8)': 'library/emux_chip8.md'
-        - 'DOS (DOSBox)': 'library/dosbox.md'
-        - 'Mattel - Intellivision (FreeIntv)': 'library/freeintv.md'
-        - 'RPG Maker 2000/2003 (EasyRPG)': 'library/easyrpg.md'
-        - 'Lua Engine (Lutro)': 'library/lutro.md'
+      - 'Microsoft Emulation':
         - 'Microsoft - MSX (fMSX)': 'library/fmsx.md'
         - 'MSX/SVI/ColecoVision/SG-1000 (blueMSX)': 'library/bluemsx.md'
-        - 'SNK - Neo Geo Pocket / Color (Beetle NeoPop)': 'library/beetle_neopop.md'
-        - 'Magnavox - Odyssey2 / Phillips Videopac+ (O2EM)': 'library/o2em.md'
-        - 'Sharp - X68000 (PX68k)': 'library/px68k.md'
-        - 'ScummVM': 'library/scummvm.md'
-        - 'Thomson - MO/TO (Theodore)': 'library/theodore.md'
-        - 'Uzebox (Uzem)': 'library/uzem.md'
-        - 'GCE - Vectrex (vecx)': 'library/vecx.md'
-        - 'Bandai - WonderSwan/Color (Beetle Cygne)': 'library/beetle_cygne.md'
-        - 'Bandai - Wonderswan Compatibility List': 'library/compatibility/wswan.md'
-        - 'ZX Spectrum (Fuse)': 'library/fuse.md'
-        - 'Sinclair - ZX 81 (EightyOne)': 'library/eightyone.md'
-      - Nintendo Cores:
+      - 'Nintendo Emulation':
         - 'Nintendo - DS Compatibility List': 'library/compatibility/ds.md'
         - 'Nintendo - Game Boy Advance Compatibility List': 'library/compatibility/gba.md'
         - 'Nintendo - Game Boy Color Compatibility List': 'library/compatibility/gbc.md'
@@ -155,13 +154,17 @@ nav:
         - 'Nintendo - SNES / Famicom (Snes9x 2010)': 'library/snes9x_2010.md'
         - 'Nintendo - SNES / Famicom (Snes9x)': 'library/snes9x.md'
         - 'Nintendo - Virtual Boy (Beetle VB)': 'library/beetle_vb.md'
-      - NEC Cores:
+      - 'NEC Emulation':
         - 'NEC - PC-FX Compatibility List': 'library/compatibility/pcfx.md'
         - 'NEC - PC-98 (Neko Project II Kai)': 'library/neko_project_ii_kai.md'
         - 'NEC - PC Engine SuperGrafx (Beetle SGX)': 'library/beetle_sgx.md'
         - 'NEC - PC Engine / CD (Beetle PCE FAST)': 'library/beetle_pce_fast.md'
         - 'NEC - PC-FX (Beetle PC-FX)': 'library/beetle_pc_fx.md'
-      - Sega Cores:
+      - 'Phillips Emulation':
+        - 'Magnavox - Odyssey2 / Phillips Videopac+ (O2EM)': 'library/o2em.md'
+      - 'SNK Emulation':
+        - 'SNK - Neo Geo Pocket / Color (Beetle NeoPop)': 'library/beetle_neopop.md'
+      - 'Sega Emulation':
         - 'Sega - 32X Compatibility List': 'library/compatibility/32x.md'
         - 'Sega - Dreamcast Compatibility List': 'library/compatibility/dc.md'
         - 'Sega - Saturn Compatibility List': 'library/compatibility/saturn.md'
@@ -173,13 +176,27 @@ nav:
         - 'Sega - MS/MD/CD/32X (PicoDrive)': 'library/picodrive.md'
         - 'Sega - Saturn (Beetle Saturn)': 'library/beetle_saturn.md'
         - 'Sega - Saturn (Yabause)': 'library/yabause.md'
+        - 'MSX/SVI/ColecoVision/SG-1000 (blueMSX)': 'library/bluemsx.md'
         - 'VeMUlator': 'library/vemulator.md'
-      - Sony Cores:
+      - 'Sharp Emulation':
+        - 'Sharp - X68000 (PX68k)': 'library/px68k.md'
+      - 'Sinclair Emulation':
+        - 'Sinclair - ZX 81 (EightyOne)': 'library/eightyone.md'
+        - 'Sinclair - ZX Spectrum (Fuse)': 'library/fuse.md'
+      - 'Sony Emulation':
         - 'Sony - Playstation Compatibility List': 'library/compatibility/psx.md'
         - 'Sony - PlayStation (Beetle PSX)': 'library/beetle_psx.md'
         - 'Sony - PlayStation (Beetle PSX HW)': 'library/beetle_psx_hw.md'
         - 'Sony - PlayStation (PCSX ReARMed)': 'library/pcsx_rearmed.md'
         - 'Sony - PlayStation Portable (PPSSPP)': 'library/ppsspp.md'
+      - 'Special-Purpose Cores':
+        - 'Dummy Core': 'library/dummy.md'
+        - 'Remote RetroPad': 'library/remote_retropad.md'
+        - 'Video Processor': 'library/video_processor.md'
+      - 'SpectraVision Emulation':
+        - 'MSX/SVI/ColecoVision/SG-1000 (blueMSX)': 'library/bluemsx.md'
+      - 'Thomson Emulation':
+        - 'Thomson - MO/TO (Theodore)': 'library/theodore.md'
     - Shader Library:
       - 'Introduction': 'shader/introduction.md'
       - '3dfx': 'shader/3dfx.md'


### PR DESCRIPTION
This is the second half of my suggested refactoring of the Table of Contents, focused on the Core Library. 

In particular my goal was to free the entries of the "Misc" category so that they can reside in places where users might be more likely to look for them.