### PR TITLE
add mame software list guide to TOC

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -43,6 +43,7 @@ nav:
     - 'Lakka Documentation': 'http://www.lakka.tv/doc/Home/'
     - 'Core Library: Emulation':
       - 'Getting Started with Arcade Emulation': 'guides/arcade-getting-started.md'
+      - 'Getting Started with MAME Software List Emulation': 'guides/softwarelist-getting-started.md'
       - 'BIOS Information Hub': 'library/bios.md'
       - '3DO Emulation':
         - 'The 3DO Company - 3DO (4DO)': 'library/4do.md'


### PR DESCRIPTION
When building locally, mkdocs pointed out that this isn't visible in the TOC yet.