### PR TITLE
Update menu/hotkey input documentation

### DIFF
--- a/docs/guides/input-and-controls.md
+++ b/docs/guides/input-and-controls.md
@@ -76,51 +76,80 @@ Core Controls Remapping alters how the core receives input rather than how the g
 
 ### Keyboard gameplay controls
 
-| User 1 Keyboard | Default RetroPad Mapping  | User 1 Keyboard | Default RetroPad Mapping |
-|-----------------|---------------------------|-----------------|--------------------------|
-| ![Up Arrow](/image/Button_Pack/Keyboard_Mouse/Dark/Keyboard_Black_Arrow_Up.png)    | ![RetroPad Up](../image/retropad/retro_dpad_up.png)       | ![Z](/image/Button_Pack/Keyboard_Mouse/Dark/Keyboard_Black_Z.png)   | ![RetroPad B](../image/retropad/retro_b.png)       |
-| ![Down Arrow](/image/Button_Pack/Keyboard_Mouse/Dark/Keyboard_Black_Arrow_Down.png)  | ![RetroPad Down](../image/retropad/retro_dpad_down.png)     | ![X](/image/Button_Pack/Keyboard_Mouse/Dark/Keyboard_Black_X.png)   | ![RetroPad A](../image/retropad/retro_a.png)       |
-| ![Left Arrow](/image/Button_Pack/Keyboard_Mouse/Dark/Keyboard_Black_Arrow_Left.png)  | ![RetroPad Left](../image/retropad/retro_dpad_left.png)     | ![A](/image/Button_Pack/Keyboard_Mouse/Dark/Keyboard_Black_A.png)   | ![RetroPad Y](../image/retropad/retro_y.png)       | 
-| ![Right Arrow](/image/Button_Pack/Keyboard_Mouse/Dark/Keyboard_Black_Arrow_Right.png) | ![RetroPad Right](../image/retropad/retro_dpad_right.png)    | ![S](/image/Button_Pack/Keyboard_Mouse/Dark/Keyboard_Black_S.png)   | ![RetoPad X](../image/retropad/retro_x.png)       |
-| ![Q](/image/Button_Pack/Keyboard_Mouse/Dark/Keyboard_Black_Q.png)     | ![RetroPad L1](../image/retropad/retro_l1.png)            | - | - |
-| ![W](/image/Button_Pack/Keyboard_Mouse/Dark/Keyboard_Black_W.png)     | ![RetroPad R1](../image/retropad/retro_r1.png)            | - | - |
-| ![Shift](/image/Button_Pack/Keyboard_Mouse/Dark/Keyboard_Black_Shift.png) | ![RetroPad Select](../image/retropad/retro_select.png)        | - | - |
-| ![Enter](/image/Button_Pack/Keyboard_Mouse/Dark/Keyboard_Black_Enter.png) | ![RetroPad Start](../image/retropad/retro_start.png)         | - | - |
+| User 1 Keyboard                                                                       | Default RetroPad Mapping                                     |
+|---------------------------------------------------------------------------------------|--------------------------------------------------------------|
+| ![Up Arrow](/image/Button_Pack/Keyboard_Mouse/Dark/Keyboard_Black_Arrow_Up.png)       | ![RetroPad Up](../image/retropad/retro_dpad_up.png)          |
+| ![Down Arrow](/image/Button_Pack/Keyboard_Mouse/Dark/Keyboard_Black_Arrow_Down.png)   | ![RetroPad Down](../image/retropad/retro_dpad_down.png)      |
+| ![Left Arrow](/image/Button_Pack/Keyboard_Mouse/Dark/Keyboard_Black_Arrow_Left.png)   | ![RetroPad Left](../image/retropad/retro_dpad_left.png)      |
+| ![Right Arrow](/image/Button_Pack/Keyboard_Mouse/Dark/Keyboard_Black_Arrow_Right.png) | ![RetroPad Right](../image/retropad/retro_dpad_right.png)    |
+| ![Q](/image/Button_Pack/Keyboard_Mouse/Dark/Keyboard_Black_Q.png)                     | ![RetroPad L1](../image/retropad/retro_l1.png)               |
+| ![W](/image/Button_Pack/Keyboard_Mouse/Dark/Keyboard_Black_W.png)                     | ![RetroPad R1](../image/retropad/retro_r1.png)               |
+| ![Shift](/image/Button_Pack/Keyboard_Mouse/Dark/Keyboard_Black_Shift.png)             | ![RetroPad Select](../image/retropad/retro_select.png)       |
+| ![Enter](/image/Button_Pack/Keyboard_Mouse/Dark/Keyboard_Black_Enter.png)             | ![RetroPad Start](../image/retropad/retro_start.png)         |
+| ![Z](/image/Button_Pack/Keyboard_Mouse/Dark/Keyboard_Black_Z.png)                     | ![RetroPad B](../image/retropad/retro_b.png)                 |
+| ![X](/image/Button_Pack/Keyboard_Mouse/Dark/Keyboard_Black_X.png)                     | ![RetroPad A](../image/retropad/retro_a.png)                 |
+| ![A](/image/Button_Pack/Keyboard_Mouse/Dark/Keyboard_Black_A.png)                     | ![RetroPad Y](../image/retropad/retro_y.png)                 |
+| ![S](/image/Button_Pack/Keyboard_Mouse/Dark/Keyboard_Black_S.png)                     | ![RetoPad X](../image/retropad/retro_x.png)                  |
 
+### Menu controls
 
-### Keyboard GUI and hotkey bindings
+The keybord inputs shown here are active only when `Settings` → `Input` → `Unified Menu Controls` is disabled (default). Otherwise, only Retropad inputs are used.
+
+| Keyboard Input                                                                        | Retropad Input                                            | Menu Action                   |
+| ------------------------------------------------------------------------------------- | --------------------------------------------------------- | ----------------------------- |
+| ![Up Arrow](/image/Button_Pack/Keyboard_Mouse/Dark/Keyboard_Black_Arrow_Up.png)       | ![RetroPad Up](../image/retropad/retro_dpad_up.png)       | Move cursor up                |
+| ![Down Arrow](/image/Button_Pack/Keyboard_Mouse/Dark/Keyboard_Black_Arrow_Down.png)   | ![RetroPad Down](../image/retropad/retro_dpad_down.png)   | Move cursor down              |
+| ![Left Arrow](/image/Button_Pack/Keyboard_Mouse/Dark/Keyboard_Black_Arrow_Left.png)   | ![RetroPad Left](../image/retropad/retro_dpad_left.png)   | Move cursor left              |
+| ![Right Arrow](/image/Button_Pack/Keyboard_Mouse/Dark/Keyboard_Black_Arrow_Right.png) | ![RetroPad Right](../image/retropad/retro_dpad_right.png) | Move cursor right             |
+| ![Page Up](/image/Button_Pack/Keyboard_Mouse/Dark/Keyboard_Black_Page_Up.png)         | ![RetroPad L1](../image/retropad/retro_l1.png)            | Scroll one page up            |
+| ![Page Down](/image/Button_Pack/Keyboard_Mouse/Dark/Keyboard_Black_Page_Down.png)     | ![RetroPad R1](../image/retropad/retro_r1.png)            | Scroll one page down          |
+| ![Backspace](/image/Button_Pack/Keyboard_Mouse/Dark/Keyboard_Black_Backspace.png)     | ![RetroPad B](../image/retropad/retro_b.png)              | Return to the previous screen |
+| ![Enter](/image/Button_Pack/Keyboard_Mouse/Dark/Keyboard_Black_Enter.png)             | ![RetroPad A](../image/retropad/retro_a.png)              | Select Item                   |
+| -                                                                                     | ![RetroPad Y](../image/retropad/retro_y.png)              | Scan content                  |
+| ![/](/image/Button_Pack/Keyboard_Mouse/Dark/Keyboard_Black_Slash.png)                 | ![RetroPad X](../image/retropad/retro_x.png)              | Search                        |
+| ![Shift](/image/Button_Pack/Keyboard_Mouse/Dark/Keyboard_Black_Shift.png)             | ![RetroPad Select](../image/retropad/retro_select.png)    | Help                          |
+| ![Del](/image/Button_Pack/Keyboard_Mouse/Dark/Keyboard_Black_Del.png)                 | -                                                         | Remove highlighted input bind |
+| ![Space](/image/Button_Pack/Keyboard_Mouse/Dark/Keyboard_Black_Space.png)             | ![RetroPad Start](../image/retropad/retro_start.png)      | Reset to default              |
+| ![Esc](/image/Button_Pack/Keyboard_Mouse/Dark/Keyboard_Black_Esc.png)                 | -                                                         | Exit RetroArch                |
+
+### Hotkey controls
 
 Hotkey binds can be configured at `Settings` → `Input` → 'Input Hotkey Binds'. If you map `Enable Hotkeys` to a key, it will require that key to be held in order to trigger any hotkeys. This can be useful in avoiding keyboard mapping conflicts between RetroArch and cores cores that use the keyboard for input.
 
 !!! Tip
     Hotkeys can also be mapped to RetroPad buttons.
 
-Menu                        ||In-game      ||
-------------- | ------------ |------------- | ------------ 
-**Key**       | **Action**   |**Key**       |**Action**
-![Up Arrow](/image/Button_Pack/Keyboard_Mouse/Dark/Keyboard_Black_Arrow_Up.png)    | Move cursor up                  |![F1](/image/Button_Pack/Keyboard_Mouse/Dark/Keyboard_Black_F1.png)    | Menu toggle
-![Down Arrow](/image/Button_Pack/Keyboard_Mouse/Dark/Keyboard_Black_Arrow_Down.png)  | Move cursor down                |![F2](/image/Button_Pack/Keyboard_Mouse/Dark/Keyboard_Black_F2.png)    | Save state
-![Left Arrow](/image/Button_Pack/Keyboard_Mouse/Dark/Keyboard_Black_Arrow_Left.png)  | Move cursor left                |![F4](/image/Button_Pack/Keyboard_Mouse/Dark/Keyboard_Black_F4.png)    | Load state
-![Right Arrow](/image/Button_Pack/Keyboard_Mouse/Dark/Keyboard_Black_Arrow_Right.png) | Move cursor right               |![F7](/image/Button_Pack/Keyboard_Mouse/Dark/Keyboard_Black_F7.png)    | Increase current state slot
-![Page Up](/image/Button_Pack/Keyboard_Mouse/Dark/Keyboard_Black_Page_Up.png)     | Scroll one page up              |![F6](/image/Button_Pack/Keyboard_Mouse/Dark/Keyboard_Black_F6.png)    | Decrease current state slot
-![Page Down](/image/Button_Pack/Keyboard_Mouse/Dark/Keyboard_Black_Page_Down.png)   | Scroll one page down            |![F8](/image/Button_Pack/Keyboard_Mouse/Dark/Keyboard_Black_F8.png)    | Take screenshot
-![Enter](/image/Button_Pack/Keyboard_Mouse/Dark/Keyboard_Black_Enter.png)       | Select Item                       |![F9](/image/Button_Pack/Keyboard_Mouse/Dark/Keyboard_Black_F9.png)    | Mute
-![Backspace](/image/Button_Pack/Keyboard_Mouse/Dark/Keyboard_Black_Backspace.png)   | Return to the previous screen  |![F12](/image/Button_Pack/Keyboard_Mouse/Dark/Keyboard_Black_F12.png)   | Show on-screen keyboard
-![Shift](/image/Button_Pack/Keyboard_Mouse/Dark/Keyboard_Black_Shift.png)       | Help                            |![F11](/image/Button_Pack/Keyboard_Mouse/Dark/Keyboard_Black_F11.png)   | Grab mouse
-![Del](/image/Button_Pack/Keyboard_Mouse/Dark/Keyboard_Black_Del.png)         | Remove highlighted input bind | ![+](/image/Button_Pack/Keyboard_Mouse/Dark/Keyboard_Black_Plus.png)  | Volume Up
-![Space](/image/Button_Pack/Keyboard_Mouse/Dark/Keyboard_Black_Space.png)       | Reset to default | ![-](/image/Button_Pack/Keyboard_Mouse/Dark/Keyboard_Black_Minus.png) | Volume Down
-![/](/image/Button_Pack/Keyboard_Mouse/Dark/Keyboard_Black_Slash.png)  | Search  | ![Spacebar](/image/Button_Pack/Keyboard_Mouse/Dark/Keyboard_Black_Space.png) | Fast forward toggle | 
-![Esc](/image/Button_Pack/Keyboard_Mouse/Dark/Keyboard_Black_Esc.png)  | Exit RetroArch   | ![L](/image/Button_Pack/Keyboard_Mouse/Dark/Keyboard_Black_L.png) | Fast forward hold | 
-![R](/image/Button_Pack/Keyboard_Mouse/Dark/Keyboard_Black_R.png) | Rewind | ![O](/image/Button_Pack/Keyboard_Mouse/Dark/Keyboard_Black_O.png) | Movie record |
-![P](/image/Button_Pack/Keyboard_Mouse/Dark/Keyboard_Black_P.png) | Pause| ![P](/image/Button_Pack/Keyboard_Mouse/Dark/Keyboard_Black_K.png) | Frame advance |
-![H](/image/Button_Pack/Keyboard_Mouse/Dark/Keyboard_Black_H.png)  | Reset | ![E](/image/Button_Pack/Keyboard_Mouse/Dark/Keyboard_Black_E.png)     | Slow motion |
-![M](/image/Button_Pack/Keyboard_Mouse/Dark/Keyboard_Black_M.png)  | Next shader| ![F](/image/Button_Pack/Keyboard_Mouse/Dark/Keyboard_Black_F.png) | Fullscreen toggle | 
-![N](/image/Button_Pack/Keyboard_Mouse/Dark/Keyboard_Black_N.png)     | Previous shader | ![F5](/image/Button_Pack/Keyboard_Mouse/Dark/Keyboard_Black_F5.png)| Switch GUI |
-![I](/image/Button_Pack/Keyboard_Mouse/Dark/Keyboard_Black_I.png)     | Netplay toggle play/spectate |  | |
+| Keyboard Input                                                               | In-Game Action               |
+| ---------------------------------------------------------------------------- | ---------------------------- |
+| ![R](/image/Button_Pack/Keyboard_Mouse/Dark/Keyboard_Black_R.png)            | Rewind                       |
+| ![P](/image/Button_Pack/Keyboard_Mouse/Dark/Keyboard_Black_P.png)            | Pause                        |
+| ![H](/image/Button_Pack/Keyboard_Mouse/Dark/Keyboard_Black_H.png)            | Reset                        |
+| ![M](/image/Button_Pack/Keyboard_Mouse/Dark/Keyboard_Black_M.png)            | Next shader                  |
+| ![N](/image/Button_Pack/Keyboard_Mouse/Dark/Keyboard_Black_N.png)            | Previous shader              |
+| ![I](/image/Button_Pack/Keyboard_Mouse/Dark/Keyboard_Black_I.png)            | Netplay toggle play/spectate |
+| ![F1](/image/Button_Pack/Keyboard_Mouse/Dark/Keyboard_Black_F1.png)          | Menu toggle                  |
+| ![F2](/image/Button_Pack/Keyboard_Mouse/Dark/Keyboard_Black_F2.png)          | Save state                   |
+| ![F4](/image/Button_Pack/Keyboard_Mouse/Dark/Keyboard_Black_F4.png)          | Load state                   |
+| ![F7](/image/Button_Pack/Keyboard_Mouse/Dark/Keyboard_Black_F7.png)          | Increase current state slot  |
+| ![F6](/image/Button_Pack/Keyboard_Mouse/Dark/Keyboard_Black_F6.png)          | Decrease current state slot  |
+| ![F8](/image/Button_Pack/Keyboard_Mouse/Dark/Keyboard_Black_F8.png)          | Take screenshot              |
+| ![F9](/image/Button_Pack/Keyboard_Mouse/Dark/Keyboard_Black_F9.png)          | Mute                         |
+| ![F12](/image/Button_Pack/Keyboard_Mouse/Dark/Keyboard_Black_F12.png)        | Show on-screen keyboard      |
+| ![F11](/image/Button_Pack/Keyboard_Mouse/Dark/Keyboard_Black_F11.png)        | Grab mouse                   |
+| ![+](/image/Button_Pack/Keyboard_Mouse/Dark/Keyboard_Black_Plus.png)         | Volume Up                    |
+| ![-](/image/Button_Pack/Keyboard_Mouse/Dark/Keyboard_Black_Minus.png)        | Volume Down                  |
+| ![Spacebar](/image/Button_Pack/Keyboard_Mouse/Dark/Keyboard_Black_Space.png) | Fast forward toggle          |
+| ![L](/image/Button_Pack/Keyboard_Mouse/Dark/Keyboard_Black_L.png)            | Fast forward hold            |
+| ![O](/image/Button_Pack/Keyboard_Mouse/Dark/Keyboard_Black_O.png)            | Movie record                 |
+| ![P](/image/Button_Pack/Keyboard_Mouse/Dark/Keyboard_Black_K.png)            | Frame advance                |
+| ![E](/image/Button_Pack/Keyboard_Mouse/Dark/Keyboard_Black_E.png)            | Slow motion                  |
+| ![F](/image/Button_Pack/Keyboard_Mouse/Dark/Keyboard_Black_F.png)            | Fullscreen toggle            |
+| ![F5](/image/Button_Pack/Keyboard_Mouse/Dark/Keyboard_Black_F5.png)          | Switch GUI                   |
 
 ## Platform-specific controls
 
 ### Nintendo Switch
+
 USB keyboards and mice: All keyboards seem to work. Not all mice seem to work. [Mouse compatibility sheet](https://docs.google.com/spreadsheets/d/1Drbo5-QuSX901MwtOytSMuqRGxeIkq2HELM806I9dj0/edit#gid=0).
 
 Touch mouse emulation: The Switch touchscreen can be used for mouse control like a laptop touchpad. The following gestures are supported.


### PR DESCRIPTION
The documentation of menu and hotkey inputs was out-of-date and didn't reflect the retropad menu controls. This is fixed in this PR.