### PR TITLE
Update beetle_psx_hw.md

### DIFF
--- a/docs/library/beetle_psx_hw.md
+++ b/docs/library/beetle_psx_hw.md
@@ -638,6 +638,8 @@ Rumble only works in the Beetle PSX HW core when
 
 **Expect bugs with hardware renderer enhancements.**
 
+When using the run-ahead latency reduction feature, the "second instance" setting will break the hardware renderer.
+
 A list of known emulation bugs when using the software renderer can be found here [https://forum.fobby.net/index.php?t=msg&th=1114&start=0&](https://forum.fobby.net/index.php?t=msg&th=1114&start=0&)
 
 ## External Links


### PR DESCRIPTION
It took a bit of sleuthing to figure out that "second instance" breaks the hardware renderer, and I noticed the existence of a bug report wherein it took another user several months to figure the same thing out. It'd be helpful if the docs entry mentioned this fact.

https://github.com/libretro/beetle-psx-libretro/issues/443