### PR TITLE
hopefully fix '<' and '>' being translated to &lt; and &gt;

### DIFF
--- a/docs/guides/shaders.md
+++ b/docs/guides/shaders.md
@@ -43,15 +43,15 @@ The `--set-shader` command line option allows to set shaders directly, bypassing
 
 Example use:
     
-    retroarch --set-shader "D:\RetroArch\shaders\shaders_glsl\blurs\kawase_blur_5pass.glslp" -L <core> <content>
+    retroarch --set-shader "D:\RetroArch\shaders\shaders_glsl\blurs\kawase_blur_5pass.glslp" -L &lt;core&gt; &lt;content&gt;
     
 The shader path can be relative to the shader directory:
     
-    retroarch --set-shader "shaders_glsl\blurs\kawase_blur_5pass.glslp" -L <core> <content>
+    retroarch --set-shader "shaders_glsl\blurs\kawase_blur_5pass.glslp" -L &lt;core&gt; &lt;content&gt;
     
 An empty parameter effectively disables any automatic presets:
     
-    retroarch --set-shader "" -L <core> <content>
+    retroarch --set-shader "" -L &lt;core&gt; &lt;content&gt;
     
 ### Converting Cg shaders to GLSL
 In some cases, Cg shaders cannot be supported. This goes for OpenGL ES drivers, and when EGL OpenGL contexts are used (KMS mode for instance). Using Nvidia's `cgc` compiler, you can convert Cg shaders to GLSL shaders with the `cg2glsl` tool developed by us [here](https://github.com/Themaister/RetroArch/blob/master/tools/cg2glsl.py). It can convert single shaders as well as whole folder structures in batch.


### PR DESCRIPTION
## Description

https://docs.libretro.com/guides/shaders/#command-line shows
`retroarch --set-shader "" -L &lt;core&gt; &lt;content&gt;`
instead of
`retroarch --set-shader "" -L <core> <content>`
which I think is because the server uses the old `mkdocs-material-4.0.2`.

With this change, it hopefully works with this older version, either way works with the newest `mkdocs-material-4.4.1`.