### PR TITLE
Add notes regarding package management and manual changes to how Cores are installed

### DIFF
--- a/docs/guides/change-directories.md
+++ b/docs/guides/change-directories.md
@@ -26,7 +26,7 @@ Although the defaults will suit most users, if you want to configure custom BIOS
 
 ### Cores
 
-This is the location for all your cores. To [install them using the user interface](https://docs.libretro.com/guides/download-cores/#installing-cores-through-retroarch-interface), this setting needs to point to a writeable directory. 
+This is the location for all your cores. To [install them using the user interface](../download-cores/#installing-cores-through-retroarch-interface), this setting needs to point to a writeable directory. 
 
 !!! note
     The Ubuntu PPA does not point this to a user-writable directory because cores are modified by the package manager. If you want to change it manually, you might want to change this directory from "retroarch.cfg" with a text editor since the RetroArch file browser doesn't show hidden folders by default. *libretro_directory =* is what you need to change in the config file. Some distributions use `~/.config/retroarch/cores/`

--- a/docs/guides/change-directories.md
+++ b/docs/guides/change-directories.md
@@ -24,6 +24,13 @@ Although the defaults will suit most users, if you want to configure custom BIOS
 
 ## Paths to consider changing:
 
+### Cores
+
+This is the location for all your cores. To [install them using the user interface](https://docs.libretro.com/guides/download-cores/#installing-cores-through-retroarch-interface), this setting needs to point to a writeable directory. 
+
+!!! note
+    The Ubuntu PPA does not point this to a user-writable directory because cores are modified by the package manager. If you want to change it manually, you might want to change this directory from "retroarch.cfg" with a text editor since the RetroArch file browser doesn't show hidden folders by default. *libretro_directory =* is what you need to change in the config file. Some distributions use `~/.config/retroarch/cores/`
+
 ### System/BIOS
 
 This is where you specify the location for all your BIOS's, by default RetroArch looks for BIOS in your "Starting directory" folder. It is not suggested that you dump all BIOS files in the "Starting directory".

--- a/docs/guides/download-cores.md
+++ b/docs/guides/download-cores.md
@@ -22,7 +22,7 @@ Cores are essentially other programs and games that run through RetroArch. Retro
 - Select the core you want to download
 
 !!! note
-    If you're using the Ubuntu PPA version of RetroArch and have enabled "Show Core Updater" manually, your changes will not be reflected unless your the Cores directory setting is set to a writable location in the [Directory Cofiguration](https://docs.libretro.com/guides/change-directories#cores).
+    If you're using the Ubuntu PPA version of RetroArch and have enabled "Show Core Updater" manually, your changes will not be reflected unless your the Cores directory setting is set to a writable location in the [Directory Cofiguration](../change-directories#cores).
 
 ## Installing cores through package manager (Ubuntu PPA only)
 

--- a/docs/guides/download-cores.md
+++ b/docs/guides/download-cores.md
@@ -7,11 +7,22 @@ Cores are essentially other programs and games that run through RetroArch. Retro
 
 ## Installing cores through RetroArch interface
 
-![Core Updater](/image/retroarch/xmb/core_updater.gif)
+!!! tip
+    If you do not see the "Core Updater" option, you may have installed RetroArch using a package manager. If so, see [Installing cores through package manager (Ubuntu PPA only)](#installing-cores-through-package-manager-ubuntu-ppa-only). Otherwise, to enable it:
+
+    - Navigate to **Settings**
+    - Navigate to **User Interface**
+    - Navigate to **Views**
+    - Enable **Show Core Updater**
+
+![Core Updater](https://docs.libretro.com/image/retroarch/xmb/core_updater.gif)
 
 - Navigate to **Online Updater**
 - Navigate to **Select Core Updater**
 - Select the core you want to download
+
+!!! note
+    If you're using the Ubuntu PPA version of RetroArch and have enabled "Show Core Updater" manually, your changes will not be reflected unless your the Cores directory setting is set to a writable location in the [Directory Cofiguration](https://docs.libretro.com/guides/change-directories#cores).
 
 ## Installing cores through package manager (Ubuntu PPA only)
 

--- a/docs/guides/download-cores.md
+++ b/docs/guides/download-cores.md
@@ -15,7 +15,7 @@ Cores are essentially other programs and games that run through RetroArch. Retro
     - Navigate to **Views**
     - Enable **Show Core Updater**
 
-![Core Updater](https://docs.libretro.com/image/retroarch/xmb/core_updater.gif)
+![Core Updater](/image/retroarch/xmb/core_updater.gif)
 
 - Navigate to **Online Updater**
 - Navigate to **Select Core Updater**


### PR DESCRIPTION
Specifically addresses issues relating to this https://www.reddit.com/r/RetroArch/comments/8jnaqm/running_retroarch_173_from_arch_community_repo/

1. Add an explanation up-front as to why one might not see the Core Updater option and how to enable it. My justification is that because a toggle for showing "Core Updater" exists, there should be documentation on using it, -especially- at this location. If not, consider removing the toggle from the application.
2. Add 'core' directory notes to hint at the earlier documentation regarding PPA and why cores may not appear to be downloading. Ideally, the application would show a warning like "Directory is not writable" but it does not.