### PR TITLE
Update PSV instructions to refer to 1.7.9

### DIFF
--- a/docs/guides/install-psv.md
+++ b/docs/guides/install-psv.md
@@ -17,13 +17,13 @@ We're gonna download two files to get the full experience. One of these files is
 
 #### Downloading
 
-You can download a stable RetroArch by clicking [here](http://buildbot.libretro.com/stable/1.7.8/playstation/vita/RetroArch.vpk). If you want to install the Nightly version, you can also use [this link](http://buildbot.libretro.com/nightly/playstation/vita/RetroArch.vpk). 
+You can download a stable RetroArch by clicking [here](http://buildbot.libretro.com/stable/1.7.9/playstation/vita/RetroArch.vpk). If you want to install the Nightly version, you can also use [this link](http://buildbot.libretro.com/nightly/playstation/vita/RetroArch.vpk). 
 
 From now on, there are two ways to download our assets. This option will affect your setup method. We're going use the **bundle** this time.
 
 **RetroArch's data**
 
-You can download `RetroArch's data` file from [this link](http://buildbot.libretro.com/stable/1.7.8/playstation/vita/RetroArch_data.7z) or [nightly](http://buildbot.libretro.com/nightly/playstation/vita/).
+You can download `RetroArch's data` file from [this link](http://buildbot.libretro.com/stable/1.7.9/playstation/vita/RetroArch_data.7z) or [nightly](http://buildbot.libretro.com/nightly/playstation/vita/).
 
 **Bundle**
 


### PR DESCRIPTION
This PR updates PS Vita installation instructions to refer to newly released 1.7.9.

That said, I think this highlights an issue with the way PS Vita RetroArch is distributed. When looking through the docs, I found that PSV is the **only** platform to refer to direct download links instead of https://www.retroarch.com/index.php?page=platforms. The reason for this is that said page does **not** link to data files which are important.

I see three ways to solve this:
1. Make RetroArch.vpk bundle data files - I don't know how this packaging works so I don't know if it's feasible.
2. Make https://www.retroarch.com/index.php?page=platforms list two downloads: "Download VPK" and "Download assets"
3. Make https://www.retroarch.com/index.php?page=platforms link to https://buildbot.libretro.com/stable/1.7.9/playstation/vita/. I guess this would be easiest for users to understand!