### PR TITLE
Remove excess code indentation

### DIFF
--- a/docs/development/coding-standards.md
+++ b/docs/development/coding-standards.md
@@ -63,31 +63,31 @@ When possible, use whitespace to improve the readability of code that makes many
 **Example of aligning successive assignment statements*:
 
 ```c
-               if (seq == 1157460427127406720ULL)
-               {
-                  content_ctx_info_t content_info;
-                  content_info.argc                   = 0;
-                  content_info.argv                   = NULL;
-                  content_info.args                   = NULL;
-                  content_info.environ_get            = NULL;
+if (seq == 1157460427127406720ULL)
+{
+   content_ctx_info_t content_info;
+   content_info.argc                   = 0;
+   content_info.argv                   = NULL;
+   content_info.args                   = NULL;
+   content_info.environ_get            = NULL;
 
-                  ...
-               }
+   ...
+}
 ```
 
 **Example of aligning a complex parameter list**:
 
 ```c
-   if (recording_driver_get_data_ptr())
-   {
-      runloop_msg_queue_push(
-            msg_hash_to_str(MSG_RESTARTING_RECORDING_DUE_TO_DRIVER_REINIT),
-            2, 180, false,
-            NULL, MESSAGE_QUEUE_ICON_DEFAULT, MESSAGE_QUEUE_CATEGORY_INFO);
+if (recording_driver_get_data_ptr())
+{
+   runloop_msg_queue_push(
+         msg_hash_to_str(MSG_RESTARTING_RECORDING_DUE_TO_DRIVER_REINIT),
+         2, 180, false,
+         NULL, MESSAGE_QUEUE_ICON_DEFAULT, MESSAGE_QUEUE_CATEGORY_INFO);
 
-      command_event(CMD_EVENT_RECORD_DEINIT, NULL);
-      command_event(CMD_EVENT_RECORD_INIT, NULL);
-   }
+   command_event(CMD_EVENT_RECORD_DEINIT, NULL);
+   command_event(CMD_EVENT_RECORD_INIT, NULL);
+}
 ```
 
 ### vim configuration for Libretro style

--- a/docs/development/retroarch/compilation/windows.md
+++ b/docs/development/retroarch/compilation/windows.md
@@ -1,7 +1,7 @@
 # Windows 7 and later compilation and development guide
 
 !!! Warning
-    The MinGW toolchain we use in this guide no longer supports targeting Windows Vista or ealier.
+    The MinGW toolchain we use in this guide no longer supports targeting Windows Vista or earlier.
     Please refer to one of the MSVC guides for how to target older Windows versions with Visual Studio.
 
 [![Build in Windows](http://img.youtube.com/vi/OaYvc3y3VLI/0.jpg)](http://www.youtube.com/watch?v=OaYvc3y3VLI)
@@ -24,15 +24,15 @@ Follow the installation instructions and once finished start the MSYS2 shell.
 
 MSYS2 shell is a maintenance shell. We are going to use this shell to install the toolchain and other packages. First order of business is to update MSYS2. Start the MSYS2 Shell and run the following commands:
 
-``` bash
-    pacman --noconfirm -Sy
-    pacman --needed --noconfirm -S bash pacman pacman-mirrors msys2-runtime
+```bash
+pacman --noconfirm -Sy
+pacman --needed --noconfirm -S bash pacman pacman-mirrors msys2-runtime
 ```
 
 Close MSYS2 shell and start it again, and:
 
-``` bash
-    pacman --noconfirm -Su
+```bash
+pacman --noconfirm -Su
 ```
 
 Restart MSYS2 once again. In some cases you may find out that the shell starting scripts don't work. If so check the following Note.
@@ -48,44 +48,44 @@ Now we can start installing the packages we actually need.
 
 For 32-bit builds:
 
-``` bash
-    pacman -S --noconfirm --needed wget git make mingw-w64-i686-toolchain mingw-w64-i686-ntldd mingw-w64-i686-zlib mingw-w64-i686-pkg-config mingw-w64-i686-SDL2 mingw-w64-i686-libxml2 mingw-w64-i686-freetype mingw-w64-i686-python3 mingw-w64-i686-ffmpeg mingw-w64-i686-drmingw
+```bash
+pacman -S --noconfirm --needed wget git make mingw-w64-i686-toolchain mingw-w64-i686-ntldd mingw-w64-i686-zlib mingw-w64-i686-pkg-config mingw-w64-i686-SDL2 mingw-w64-i686-libxml2 mingw-w64-i686-freetype mingw-w64-i686-python3 mingw-w64-i686-ffmpeg mingw-w64-i686-drmingw
 ```
 
 For 64-bit builds:
 
-``` bash
-    pacman -S --noconfirm --needed wget git make mingw-w64-x86_64-toolchain mingw-w64-x86_64-ntldd mingw-w64-x86_64-zlib mingw-w64-x86_64-pkg-config mingw-w64-x86_64-SDL2 mingw-w64-x86_64-libxml2 mingw-w64-x86_64-freetype mingw-w64-x86_64-python3 mingw-w64-x86_64-ffmpeg mingw-w64-x86_64-drmingw
+```bash
+pacman -S --noconfirm --needed wget git make mingw-w64-x86_64-toolchain mingw-w64-x86_64-ntldd mingw-w64-x86_64-zlib mingw-w64-x86_64-pkg-config mingw-w64-x86_64-SDL2 mingw-w64-x86_64-libxml2 mingw-w64-x86_64-freetype mingw-w64-x86_64-python3 mingw-w64-x86_64-ffmpeg mingw-w64-x86_64-drmingw
 ```
-    
+
 You might want to install Qt too if you want to be able to use the desktop GUI.
 
 For 32-bit builds:
 
-``` bash
-    pacman -S --noconfirm --needed mingw-w64-i686-qt5 mingw-w64-i686-openssl
+```bash
+pacman -S --noconfirm --needed mingw-w64-i686-qt5 mingw-w64-i686-openssl
 ```
 
 For 64-bit builds:
 
-``` bash
-    pacman -S --noconfirm --needed mingw-w64-x86_64-qt5  mingw-w64-x86_64-openssl
+```bash
+pacman -S --noconfirm --needed mingw-w64-x86_64-qt5  mingw-w64-x86_64-openssl
 ```
 
 The NVIDIA CG toolkit package hasn't been updated for a while so you need to download that package manually and install with pacman. You can download the packages from sourceforge at the following locations: [32-bit](http://sourceforge.net/projects/msys2/files/REPOS/MINGW_GCC_4_9/i686/mingw-w64-i686-nvidia-cg-toolkit-3.1-2-any.pkg.tar.xz/download) / [64-bit](http://sourceforge.net/projects/msys2/files/REPOS/MINGW_GCC_4_9/x86_64/mingw-w64-x86_64-nvidia-cg-toolkit-3.1-2-any.pkg.tar.xz/download). Alternatively you can use the following commands directly:
 
 For 32-bit builds:
 
-``` bash
-    wget http://sourceforge.net/projects/msys2/files/REPOS/MINGW_GCC_4_9/i686/mingw-w64-i686-nvidia-cg-toolkit-3.1-2-any.pkg.tar.xz/download -O mingw-w64-i686-nvidia-cg-toolkit-3.1-2-any.pkg.tar.xz
-    pacman -U mingw-w64-i686-nvidia-cg-toolkit-3.1-2-any.pkg.tar.xz
+```bash
+wget http://sourceforge.net/projects/msys2/files/REPOS/MINGW_GCC_4_9/i686/mingw-w64-i686-nvidia-cg-toolkit-3.1-2-any.pkg.tar.xz/download -O mingw-w64-i686-nvidia-cg-toolkit-3.1-2-any.pkg.tar.xz
+pacman -U mingw-w64-i686-nvidia-cg-toolkit-3.1-2-any.pkg.tar.xz
 ```
 
 For 64-bit builds:
            
-``` bash
-    wget https://sourceforge.net/projects/mingw-w64-archlinux/files/x86_64/mingw-w64-nvidia-cg-toolkit-3.1-2-any_4.pkg.tar.xz/download -O mingw-w64-x86_64-nvidia-cg-toolkit-3.1-2-any.pkg.tar.xz
-    pacman -U mingw-w64-x86_64-nvidia-cg-toolkit-3.1-2-any.pkg.tar.xz
+```bash
+wget https://sourceforge.net/projects/mingw-w64-archlinux/files/x86_64/mingw-w64-nvidia-cg-toolkit-3.1-2-any_4.pkg.tar.xz/download -O mingw-w64-x86_64-nvidia-cg-toolkit-3.1-2-any.pkg.tar.xz
+pacman -U mingw-w64-x86_64-nvidia-cg-toolkit-3.1-2-any.pkg.tar.xz
 ```
 
 Once these packages are installed close MSYS2 shell and open MinGW-w32 shell or MinGW-w64 shell depending on the platform you want to build for.
@@ -104,31 +104,31 @@ You can find the repository directly at [GitHub](https://github.com/libretro/Ret
 
 Start the MINGW64 or the MINGW32 shell depending on what you want to compile and run the following commands:
 
-``` bash
-    git clone https://github.com/libretro/RetroArch.git retroarch
+```bash
+git clone https://github.com/libretro/RetroArch.git retroarch
 ```
 
 For subsequent builds you will need to pull the changes from the repo
 
-``` bash
-    cd retroarch
-    git pull
+```bash
+cd retroarch
+git pull
 ```
 
 To compile RetroArch run the following commands inside RetroArch's source tree:
 
-``` bash
-    ./configure
-    make clean
-    make -j4
+```bash
+./configure
+make clean
+make -j4
 ```
 
 For development purposes you might want to run a debug build instead. In such case use the following commands:
 
-``` bash
-    ./configure
-    make clean
-    make DEBUG=1 GL_DEBUG=1 -j4
+```bash
+./configure
+make clean
+make DEBUG=1 GL_DEBUG=1 -j4
 ```
 
 To facilitate debugging you can get an integrated crash handler by replacing the configure step with (debug builds only):
@@ -137,21 +137,21 @@ To facilitate debugging you can get an integrated crash handler by replacing the
 
 After a few minutes you should be able to find retroarch.exe under that directory. To start the newly compiled retroarch you can use:
 
-``` bash
-    ./retroarch
+```bash
+./retroarch
 ```
 
 ### Packaging RetroArch
 
 You might not be able to start your own build outside that environment. You might want to try to get all the required DLLs by running the following script in your destination RetroArch folder (not the git repo folder):
 
-``` bash
+```bash
 for i in $(seq 3); do for bin in $(ntldd -R *exe | grep -i mingw | cut -d">" -f2 | cut -d" " -f2); do cp -vu "$bin" . ; done; done
 ```
 
 If Qt is enabled for your build (detected automatically by default), the following is also needed:
 
-``` bash
+```bash
 windeployqt --release --no-patchqt --no-translations retroarch.exe
 for i in $(seq 3); do for bin in $(ntldd -R imageformats/*dll | grep -i mingw | cut -d">" -f2 | cut -d" " -f2); do cp -vu "$bin" . ; done; done
 ```
@@ -166,26 +166,26 @@ If you really want to get the required libraries for distribution or for persona
 
 Install **ccache** for 32-bit builds:
 
-``` bash
-    pacman -S --noconfirm --needed make mingw-w64-i686-ccache
+```bash
+pacman -S --noconfirm --needed make mingw-w64-i686-ccache
 ```
 
 Install **ccache** for 64-bit builds:
 
-``` bash
-    pacman -S --noconfirm --needed mingw-w64-x86_64-ccache
+```bash
+pacman -S --noconfirm --needed mingw-w64-x86_64-ccache
 ```
 
 Configure paths for 32-bit builds:
 
-``` bash
-    export PATH=/mingw32/lib/ccache/bin/:$PATH
+```bash
+export PATH=/mingw32/lib/ccache/bin/:$PATH
 ```
 
 Configure paths for 64-bit builds:
 
-``` bash
-    export PATH=/mingw64/lib/ccache/bin/:$PATH
+```bash
+export PATH=/mingw64/lib/ccache/bin/:$PATH
 ```
 
 !!! tip
@@ -210,8 +210,8 @@ With **ccache**:
 
 Strip **retroarch**: 
 
-``` bash
-    strip -s retroarch.exe
+```bash
+strip -s retroarch.exe
 ```
 
 ## Core Compilation
@@ -223,23 +223,23 @@ You can find the cores on libretro's [GitHUB organization](https://github.com/li
 We have an all-in-one tool to fetch and compile cores which you can use to streamline the process.
 You can obtain the tool by using these commands:
 
-``` bash
-    git clone https://github.com/libretro/libretro-super.git
-    cd libretro-super
+```bash
+git clone https://github.com/libretro/libretro-super.git
+cd libretro-super
 ```
 
 Then you can fetch one or all the cores by using **libretro-fetch.sh**
 
 Fetch all cores:
 
-``` bash
-    ./libretro-fetch.sh
+```bash
+./libretro-fetch.sh
 ```
 
 Fetch one core:
 
-``` bash
-    ./libretro-fetch.sh *corename*
+```bash
+./libretro-fetch.sh *corename*
 ```
 
 !!! Note
@@ -251,14 +251,14 @@ Fetch one core:
 
 The easiest way to build all the cores is to use **libretro-build.sh** from within libretro-super's source tree:
 
-``` bash
-    ./libretro-build.sh
+```bash
+./libretro-build.sh
 ```
 
 In case you only want to build one and/or more cores instead of all, you can specify the cores you want to build after the first command in no particular order:
 
-``` bash
-    ./libretro-build.sh snes9x2010 fceumm
+```bash
+./libretro-build.sh snes9x2010 fceumm
 ```
 
 Once compilation has finished, you can find the libretro cores inside *dist/win*.
@@ -267,26 +267,25 @@ Once compilation has finished, you can find the libretro cores inside *dist/win*
 
 Get the core's source tree. As an example we'll use [fceumm](https://github.com/libretro/libretro-fceumm/)
 
-``` bash
-    git clone https://github.com/libretro/libretro-fceumm.git
+```bash
+git clone https://github.com/libretro/libretro-fceumm.git
 ```
 
 Then compile the core: 
 
-``` bash
-    cd libretro-fceumm
-    make -f Makefile.libretro
+```bash
+cd libretro-fceumm
+make -f Makefile.libretro
 ```
 
 Optionally strip the build product:
 
-``` bash
-    strip fceumm_libretro.dll
-``
-    
+```bash
+strip fceumm_libretro.dll
+```
+
 Most cores will build with these instructions. You might need to browse to a subdirectory in some cases.
 
-```
 #### Video Tutorial
 
 [![Quick Video Demonstration](http://img.youtube.com/vi/OaYvc3y3VLI/0.jpg)](http://www.youtube.com/watch?v=OaYvc3y3VLI)

--- a/docs/development/shader/cg-shaders.md
+++ b/docs/development/shader/cg-shaders.md
@@ -206,35 +206,35 @@ We encourage new shaders targeting Libretro frontends to be written in this form
 ### Another example Cg shader
 
 ```c
-    void main_vertex
-    (
-       float4 position : POSITION,
-       out float4 oPosition : POSITION,
-       uniform float4x4 modelViewProj,
-       float2 tex : TEXCOORD,
-       out float2 oTex : TEXCOORD
-    )
-    {
-       oPosition = mul(modelViewProj, position);
-       oTex = tex;
-    }
-    
-    float4 main_fragment (float2 tex : TEXCOORD, uniform sampler2D s0 : TEXUNIT0) : COLOR
-    {
-       return tex2D(s0, tex);
-    }
+void main_vertex
+(
+   float4 position : POSITION,
+   out float4 oPosition : POSITION,
+   uniform float4x4 modelViewProj,
+   float2 tex : TEXCOORD,
+   out float2 oTex : TEXCOORD
+)
+{
+   oPosition = mul(modelViewProj, position);
+   oTex = tex;
+}
+
+float4 main_fragment (float2 tex : TEXCOORD, uniform sampler2D s0 : TEXUNIT0) : COLOR
+{
+   return tex2D(s0, tex);
+}
 ```
 
 ### Example Cg preset
 
 ```c
-    shaders = 2
-    shader0 = 4xBR-v3.9.cg
-    scale_type0 = source
-    scale0 = 4.0
-    filter_linear0 = false
-    shader1 = dummy.cg
-    filter_linear1 = true
+shaders = 2
+shader0 = 4xBR-v3.9.cg
+scale_type0 = source
+scale0 = 4.0
+filter_linear0 = false
+shader1 = dummy.cg
+filter_linear1 = true
 ```
 
 ### Entry points:
@@ -256,22 +256,22 @@ The texture coordinate origin is defined to be top-left oriented. A texture coor
 Some parameters will need to be passed to all shaders, both vertex and fragment program. A generic entry point for fragment shader will look like:
 
 ```c
-   float4 main_fragment (float2 tex : TEXCOORD0, 
-      uniform input IN, uniform sampler2D s_p : TEXUNIT0) : COLOR
-   {}
+float4 main_fragment (float2 tex : TEXCOORD0, 
+   uniform input IN, uniform sampler2D s_p : TEXUNIT0) : COLOR
+{}
 ```
 
 The input is a struct:
 
 ```c
-   struct input
-   {
-      float2 video_size;
-      float2 texture_size;
-      float2 output_size;
-      float frame_count;
-      float frame_direction;
-   };
+struct input
+{
+   float2 video_size;
+   float2 texture_size;
+   float2 output_size;
+   float frame_count;
+   float frame_direction;
+};
 ```
 
    - `TEXCOORD0`: Texture coordinates for the current input frame will be passed in `TEXCOORD0`. (`TEXCOORD` is a valid alias for `TEXCOORD0`).

--- a/docs/development/shader/glsl-shaders.md
+++ b/docs/development/shader/glsl-shaders.md
@@ -10,23 +10,23 @@ As GLSL shaders are normally placed in two different files (`vertex`, `fragment`
     GLSL shaders must be modern style, and using ruby prefix is discouraged.
 
 ```c
-    varying vec2 tex_coord;
-    #if defined(VERTEX)
-    attribute vec2 TexCoord;
-    attribute vec2 VertexCoord;
-    uniform mat4 MVPMatrix;
-    void main()
-    {
-        gl_Position = MVPMatrix * vec4(VertexCoord, 0.0, 1.0);
-        tex_coord = TexCoord;
-    }
-    #elif defined(FRAGMENT)
-    uniform sampler2D Texture;
-    void main()
-    {
-        gl_FragColor = texture2D(Texture, tex_coord);
-    }
-    #endif
+varying vec2 tex_coord;
+#if defined(VERTEX)
+attribute vec2 TexCoord;
+attribute vec2 VertexCoord;
+uniform mat4 MVPMatrix;
+void main()
+{
+    gl_Position = MVPMatrix * vec4(VertexCoord, 0.0, 1.0);
+    tex_coord = TexCoord;
+}
+#elif defined(FRAGMENT)
+uniform sampler2D Texture;
+void main()
+{
+    gl_FragColor = texture2D(Texture, tex_coord);
+}
+#endif
 ```
 
 ### GLSL presets

--- a/docs/library/mame2003_plus.md
+++ b/docs/library/mame2003_plus.md
@@ -221,12 +221,12 @@ For games where dip switches are not available directly within the MAME menu, MA
 
 ### High scores
 
-The **hiscore.dat** is compiled into MAME 2003-Plus and then spawned into `/libretro system dir/mame2003-plus/` the first time the core is run. Users do not need to install the **hiscore.dat** themselves. From then on, users can modify or replace this file with their own custom DAT if they choose. When high scores are saved, they are either stored as NVRAM data in ``` libretro system dir/mame2003-plus/nvram/ ```or as hiscore data in: ``` libretro system dir/mame2003-plus/hi/ ```
+The **hiscore.dat** is compiled into MAME 2003-Plus and then spawned into `/libretro system dir/mame2003-plus/` the first time the core is run. Users do not need to install the **hiscore.dat** themselves. From then on, users can modify or replace this file with their own custom DAT if they choose. When high scores are saved, they are either stored as NVRAM data in `libretro system dir/mame2003-plus/nvram/` or as hiscore data in: `libretro system dir/mame2003-plus/hi/`
 
 
 ### Cheats
 
-MAME 2003-Plus supports the MAME cheat engine, allowing you to use the MAME menu to enable various in-game cheats. To activate these, there is a necessary supplementary file called `cheat.dat`. This file can be [downloaded from the MAME 2003-Plus 'metadata' repository](https://github.com/libretro/mame2003-plus-libretro/tree/master/metadata). Place `cheat.dat` in: `libretro system dir/mame2003-plus/ `.
+MAME 2003-Plus supports the MAME cheat engine, allowing you to use the MAME menu to enable various in-game cheats. To activate these, there is a necessary supplementary file called `cheat.dat`. This file can be [downloaded from the MAME 2003-Plus 'metadata' repository](https://github.com/libretro/mame2003-plus-libretro/tree/master/metadata). Place `cheat.dat` in: `libretro system dir/mame2003-plus/`.
 
 
 ### History DAT

--- a/docs/library/mame_2003.md
+++ b/docs/library/mame_2003.md
@@ -86,7 +86,7 @@ BIOS romsets are not needed when using "Full Non-Merged" arcade romsets. For "Sp
 
 ### MAME menu
 
-To access the MAME internal menu, press the 'TAB' key or RetroPad R2. If you rebind MAME global inputs ('Input (general)'), it will update a file in  ``` /libretro savefile dir/mame2003/cfg/ ```   **default.cfg**. Note: If you rebind MAME global inputs ('Input (general)'), it will update a file in  ``` /libretro savefile dir/mame2003/cfg/ ```   **default.cfg**.
+To access the MAME internal menu, press the 'TAB' key or RetroPad R2. If you rebind MAME global inputs ('Input (general)'), it will update a file in  `/libretro savefile dir/mame2003/cfg/`   **default.cfg**. Note: If you rebind MAME global inputs ('Input (general)'), it will update a file in  `/libretro savefile dir/mame2003/cfg/`   **default.cfg**.
 
 ## Controllers
 
@@ -116,7 +116,7 @@ The core supports one controller setting(s):
 
 ### Service menu
 
-MAME 2003 can ability to access games' internal service menus to set permanent game options. This allows you to, for example, configure a game to be 'free play' (no need to insert coins). To access the MAME service, press the 'F2' key. After changing options in the service mode, the game's internal memory will be stored to an .nv file in: ``` /libretro savefile dir/mame2003/nvram/ ```
+MAME 2003 can ability to access games' internal service menus to set permanent game options. This allows you to, for example, configure a game to be 'free play' (no need to insert coins). To access the MAME service, press the 'F2' key. After changing options in the service mode, the game's internal memory will be stored to an .nv file in: `/libretro savefile dir/mame2003/nvram/`
 
 ### Dip-switches
 
@@ -124,7 +124,7 @@ Similarly to the [Service menu](#service-menu), many arcade games had hardware s
 
 ### High scores
 
-When high scores are saved, they are either stored as NVRAM data in ``` libretro system dir/mame2003/nvram/ ```or as hiscore data in: ``` libretro system dir/mame2003/hi/ ```
+When high scores are saved, they are either stored as NVRAM data in `libretro system dir/mame2003/nvram/` or as hiscore data in: `libretro system dir/mame2003/hi/`
 
 ### Save states
 
@@ -132,9 +132,9 @@ MAME 2003-Plus supports save states for many, but not all games.
 
 ### Cheats
 
-MAME 2003-Plus supports the MAME cheat engine, allowing you to use the MAME menu to enable various in-game cheats. To active these, there is a necessary supplementary file called `cheat.dat`. This file can be [downloaded from the MAME 2003 'metadata' repository](https://github.com/libretro/mame2003-libretro/tree/master/metadata). Place `cheat.dat` in: ``` libretro system dir/mame2003-plus/ ``` 
+MAME 2003-Plus supports the MAME cheat engine, allowing you to use the MAME menu to enable various in-game cheats. To active these, there is a necessary supplementary file called `cheat.dat`. This file can be [downloaded from the MAME 2003 'metadata' repository](https://github.com/libretro/mame2003-libretro/tree/master/metadata). Place `cheat.dat` in: `libretro system dir/mame2003-plus/` 
 
-Additionally, the 'enabled cheats' core option needs to be turned on. This option is is called: ``` mame2003-cheats = "enabled" ```
+Additionally, the 'enabled cheats' core option needs to be turned on. This option is is called: `mame2003-cheats = "enabled"`
 
 -----------
 


### PR DESCRIPTION
* Remove excess indentation at the start of code blocks
* Strip excess whitespace
* Fix a code block that wasn't closed correctly
* Correct a typo