### PR TITLE
Update beetle_pc_fx.md

### DIFF
--- a/docs/library/beetle_pc_fx.md
+++ b/docs/library/beetle_pc_fx.md
@@ -191,9 +191,9 @@ The Beetle PC-FX core supports the following device type(s) in the controls menu
 
 ## Compatibility
 
-| Game                                                                | Issue                                                   |
-|---------------------------------------------------------------------|---------------------------------------------------------|
-| Pia Carrot e Youkoso!! (Japan) [T-En by David Michel + filler v1.0] | Doesn't boot. Confirmed to work on real hardware.       |
+| Game                                                            | Issue                                                   |
+|-----------------------------------------------------------------|---------------------------------------------------------|
+|                                                                 |                                                         |
 
 ## External Links
 


### PR DESCRIPTION
Remove compatibility notes about Pia-Carrot translation.

There are now 2 patches for this game. The old one released by David Michel, filler, worked only on Magic Engine if checksum are not corrected. This patch only worked on a single .bin version of the game https://www.romhacking.net/translations/1372/

A newer patch from BabaJeanmel labeled as "Addendum" works on commonly available ReDump images.  https://www.romhacking.net/translations/5204/