### PR TITLE
Clarify firmware requirement

### DIFF
--- a/docs/library/flycast.md
+++ b/docs/library/flycast.md
@@ -77,16 +77,16 @@ RetroArch database(s) that are associated with the flycast core:
 
 Required or optional firmware files go in RetroArch's system directory.
 
-|   Filename      |    Description                |              md5sum              |
-|:--------------:|:------------------------------:|:--------------------------------:|
-| dc/dc_boot.bin  | Dreamcast BIOS - Requried     | e10c53c2f8b90bab96ead2d368858623 |
-| dc/dc_flash.bin | Date/Time/Language - Required | 0a93f7940c455905bea6e392dfde92a4 |
-| dc/naomi.bin| NAOMI Bios - Optional/Required for NAOMI Games | 3bffafac42a7767d8dcecf771f5552ba |
-* A MAME format BIOS file (naomi.zip) from a recent (post 0.154) MAME build can be used instead of naomi.bin
+|   Filename      |    Description                                                                       |              md5sum              |
+|:---------------:|:------------------------------------------------------------------------------------:|:--------------------------------:|
+| dc/dc_boot.bin  | Dreamcast BIOS - Requried                                                            | e10c53c2f8b90bab96ead2d368858623 |
+| dc/dc_flash.bin | Date/Time/Language - Required                                                        | 0a93f7940c455905bea6e392dfde92a4 |
+| dc/naomi.zip    | A MAME format BIOS file (naomi.zip) from a recent (post 0.154) MAME build - Required |                                  |
 
 !!! attention
-	The 'dc_boot.bin' and 'dc_flash.bin' firmware files need to be in a directory named 'dc' in RetroArch's system directory.
-	
+        1. naomi.zip must include the epr-21576g.ic27 file (md5sum:3bffafac42a7767d8dcecf771f5552ba)
+	2. The 'dc_boot.bin', 'dc_flash.bin', and 'naomi.zip' files need to be in a directory named 'dc' in RetroArch's system directory.
+
 ## Features
 
 | Feature           | Supported |


### PR DESCRIPTION
Hi @markwkidd @flyinghead
changes reflect my experience with flycast 0.1 (from the online downloader https://github.com/libretro/flycast/commit/1dc65b0edcdf9320ee9104355a7580a0de2cdc69) on RA (home compiled https://github.com/libretro/RetroArch/commit/4d36f0d356bc98ea6f5c7caa8d6a2669fbc6f919)
core does not start with dc/naomi.bin or dc/naomi_boot.bin (md5 both 3bffafac42a7767d8dcecf771f5552ba) but works fine with naomi.zip which content is listed below.

01d81b7ca078fd0f817ab119e25d8172  dcnaodev.bios
5a5aaef2d2cfee058283aac16e6b07af  epr-21576a.ic27
ed0137b360af98b7e1c255d153faeb16  epr-21576b.ic27
97390f07efebf711e30df0cfab2275d4  epr-21576c.ic27
f9531e2e0b6308cca09348a5a70f414d  epr-21576d.ic27
7197100badf84fdee8f709b34ee0af0a  epr-21576e.ic27
3bffafac42a7767d8dcecf771f5552ba  epr-21576g.ic27
d1e4be4862f1f9592b17a042abc5831e  epr-21576h.ic27
ffcdc59de17d41a8738352e8e4dd6579  epr-21576.ic27
18572b7a245f945f11ac10720f980303  epr-21577a.ic27
8eb73e29ad741aca44510f8a7e7fbc5e  epr-21577d.ic27
3aad8a5fbbd4f037306bba346a571241  epr-21577e.ic27
10a8a5913111672f8f40f5aa509189e6  epr-21577g.ic27
3fa70886c90c0b122b60474d847a9e7a  epr-21577h.ic27
9bb22b5907e77b22a79c1f6268c606ef  epr-21578a.ic27
f028262fdb8fb097523a94a8d8b14ef1  epr-21578d.ic27
56b622fd635765259e351960f4094a56  epr-21578e.ic27
80b4fe0a759ca1ad6dc63bd9b41b7480  epr-21578g.ic27
57a461e0b37d886e6f069d019f3f8cf0  epr-21578h.ic27
765bc6e3366d3d63593a59febb4acc53  epr-21579d.ic27
311b463797af7be9382273075a50ac3b  epr-21579.ic27
edeed38a9795e062a9af28c3eba22040  main_eeprom.bin
960ece0dc22a7c5ff81c812a2993e7cc  x76f100_eeprom.bin