### PR TITLE
Update Theodore doc

### DIFF
--- a/docs/library/theodore.md
+++ b/docs/library/theodore.md
@@ -3,7 +3,7 @@
 ## Background
 
 Theodore is a Thomson MO/TO system emulator based on Daniel Coulom's DCTO8D/DCTO9P/DCMO5 emulators. [Thomson MO/TO](https://en.wikipedia.org/wiki/Thomson_computers) is a family of 8-bit home computers produced by French company Thomson SA between 1982 and 1989.
-At the time of this writing, Theodore emulates the following models of the MO/TO family: TO8, TO8D, TO9, TO9+, MO5 and MO6.
+At the time of this writing, Theodore emulates the following models of the MO/TO family: TO7, TO7/70, TO8, TO8D, TO9, TO9+, MO5 and MO6.
 It also emulates the [Olivetti Prodest PC128](https://it.wikipedia.org/wiki/Olivetti_Prodest_PC_128), a rebranded MO6 for the Italian market.
 
 The Theodore core has been authored by
@@ -98,7 +98,7 @@ The "Start" button of the controller can be used to start the game. The core wil
 
 The Theodore core has the following option(s) that can be tweaked from the core options menu. The default setting is bolded.
 
-- **Thomson model** [theodore_rom]  (**Auto**|TO8|TO8D|TO9|TO9+|MO5|MO6|PC128)
+- **Thomson model** [theodore_rom]  (**Auto**|TO8|TO8D|TO9|TO9+|MO5|MO6|PC128|TO7|TO7/70)
 
 - **Auto run game** [theodore_autorun] (**disabled**|enabled)
 
@@ -122,8 +122,8 @@ The Theodore core supports the following device type(s) in the controls menu, bo
 
 ## Joypad
 
-| RetroPad Inputs                        | User 1 input descriptors       |
-|----------------------------------------|--------------------------------|
+| RetroPad Inputs                      | User 1 input descriptors       |
+|--------------------------------------|--------------------------------|
 | ![](/image/retropad/retro_b.png)     | "Fire" button                  |
 | ![](/image/retropad/retro_x.png)     | Virtual keyboard: go up        |
 | ![](/image/retropad/retro_y.png)     | Virtual keyboard: go down      |
@@ -165,8 +165,8 @@ The order of the keys in the virtual keyboard is: digits (0->9) then letters (A-
 
 ## Mouse
 
-| RetroMouse Inputs                                     | Theodore Inputs      |
-|-------------------------------------------------------|----------------------|
+| RetroMouse Inputs                                   | Theodore Inputs      |
+|-----------------------------------------------------|----------------------|
 | ![](/image/retromouse/retro_mouse.png) Mouse Cursor | Light pen cursor     |
 | ![](/image/retromouse/retro_left.png) Mouse 1       | Selection            |
 


### PR DESCRIPTION
Add TO7 and TO7/70 to the list of Thomson computers emulated by the Theodore core.