### PR TITLE
Added config file syntax for each "flavor" of mapping

### DIFF
--- a/docs/library/mame2003_plus.md
+++ b/docs/library/mame2003_plus.md
@@ -118,20 +118,20 @@ No system of default input mappings can address the full range of emulated games
 
 | **Classic Gamepad** |
 |---------------------|
-| The **Classic Gamepad** is based on mainline MAME's default Xbox 360 controller layout and is also likely to suit DualShock or SNES-style gamepads.<br>![Xbox 360-style RetroPad](/image/controller/xbox360.png)<br>![PSX DualShock-style RetroPad](/image/controller/psx.png) |
+| The **Classic Gamepad** is based on mainline MAME's default Xbox 360 controller layout and is also likely to suit DualShock or SNES-style gamepads. The corresponding option in configuration file is ```input_libretro_device_pX = "1"``` (where X is the player number, ```input_libretro_device_p1 = "1"``` for player 1, etc.).<br>![Xbox 360-style RetroPad](/image/controller/xbox360.png)<br>![PSX DualShock-style RetroPad](/image/controller/psx.png) |
 
 | **Modern Fightstick** |
 |-----------------------|
-| The **Modern Fightstick** layout is the fight stick and pad layout popularized by Street Fighter IV and assumes an 8+ button controller. Gamepad can also serve as an alternative Xbox/PSX-style layout for Street Fighter 2.<br>For arcade control panels, **Modern Fightstick** can be mapped in this way:<br>
+| The **Modern Fightstick** layout is the fight stick and pad layout popularized by Street Fighter IV and assumes an 8+ button controller. The corresponding option in configuration file is ```input_libretro_device_pX = "257"``` (where X is the player number, ```input_libretro_device_p1 = "257"``` for player 1, etc.). Gamepad can also serve as an alternative Xbox/PSX-style layout for Street Fighter 2.<br>For arcade control panels, **Modern Fightstick** can be mapped in this way:<br>
 ![Modern Fightstick mapping for arcade controls](/image/core/mame2003-plus/fightstick.png)|
 
 | **6-Button** |
 |--------------|
-| **6-button** is a layout intended for SNES-type RetroPad controls as well as 6-button arcade panels arcade panels that are mapped like this:<br>![6-button mapping for arcade controls](/image/core/mame2003-plus/6button.png)|
+| **6-button** is a layout intended for SNES-type RetroPad controls as well as 6-button arcade panels arcade panels. The corresponding option in configuration file is ```input_libretro_device_pX = "769"``` (where X is the player number, ```input_libretro_device_p1 = "769"``` for player 1, etc.). **6-button** can be mapped in this way:<br>![6-button mapping for arcade controls](/image/core/mame2003-plus/6button.png)|
 
 | **8-Button** |
 |--------------|
-|**8-button** is a layout intended for an arcade panel that is configured like this<br>![8-button mapping for arcade controls](/image/core/mame2003-plus/8button.png)|
+|**8-button** is a layout intended for an arcade panel. The corresponding option in configuration file is ```input_libretro_device_pX = "513"``` (where X is the player number, ```input_libretro_device_p1 = "513"``` for player 1, etc.). **8-button** is configured like this<br>![8-button mapping for arcade controls](/image/core/mame2003-plus/8button.png)|
 
 
 ### Keyboard Input


### PR DESCRIPTION
Added the configuration file syntax for each "flavor" of mapping (classic, modern, 6 buttons and 8 buttons) :

Classic Gamepad:	input_libretro_device_p1 = "1"
Modern Fighstick:	input_libretro_device_p1 = "257"
6 Buttons:		input_libretro_device_p1 = "769"
8 Buttons:		input_libretro_device_p1 = "513"