### PR TITLE
Fixes to coding style enforcement and libretro startup

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,21 +1,20 @@
-# EditorConfig is awesome: http://EditorConfig.org
+# Libretro coding standards
+# See https://libretro.readthedocs.io/en/latest/development/coding-standards/
+# Or search for "Libretro Coding Standards"
 
-# top-most EditorConfig file
 root = true
 
-# Unix-style newlines with a newline ending every file
 [*]
 end_of_line = lf
 insert_final_newline = true
+trim_trailing_whitespace = true
 charset = utf-8
 
-# Tab indentation (no size specified)
 [Makefile]
-indent_style = tab
+indent_style = space
+indent_size = 3
 
-# Matches multiple files with brace expansion notation
-# Set default charset
 [*.{c,h}]
 indent_style = space
-indent_size = 2
-trim_trailing_whitespace = true
+indent_size = 3
+max_line_length = 80

--- a/docs/development/coding-standards.md
+++ b/docs/development/coding-standards.md
@@ -38,8 +38,8 @@ Brace usage follows "Allman style". The brace associated with a control statemen
 ```c
 while (x == y)
 {
-    something();
-    somethingelse();
+   something();
+   somethingelse();
 }
 
 finalthing();
@@ -60,7 +60,7 @@ else
 
 When possible, use whitespace to improve the readability of code that makes many assignment statements in a row, uses complex conditionals, or passes a large number of paramters to a function.
 
-**Example of aligning successive assignment statements*:
+**Example of aligning successive assignment statements**:
 
 ```c
 if (seq == 1157460427127406720ULL)
@@ -95,9 +95,10 @@ if (recording_driver_get_data_ptr())
 Coders who use the **vim** editor can create a `vimrc` configuration file with the following settings in order to pre-set RetroArch indentation style.
 
 ```
-set hls
-set ts=3
-set sw=3
+set tabstop=3
+set shiftwidth=3
+set expandtab
+set textwidth=80
 ```
 
 ## Standards for Libretro cores

--- a/docs/development/cores/developing-cores.md
+++ b/docs/development/cores/developing-cores.md
@@ -62,13 +62,13 @@ The program flow of a frontend using the libretro API can be expressed as follow
 
 This function should return RETRO_API_VERSION, defined in libretro.h. It is used by the frontend to determine if ABI/API are mismatched. The ver- sion will be bumped should there be any non- compatible changes to the API. Changes to retro_* structures, as well as changes in publically visible functions and/or their arguments will warrant a bump in API version.
 
-#### `retro_init()`
-
-This function is called once, and gives the implementation a chance to initialize data structures.
-
 #### `retro_set_*()`
 
 Libretro is callback based. The frontend will set all callbacks at this stage, and the implementation must store these function pointers somewhere. The frontend can, at a later stage, call these.
+
+#### `retro_init()`
+
+This function is called once, and gives the implementation a chance to initialize data structures.
 
 #### Environment callback
 


### PR DESCRIPTION
Fixed issues with the way coding style was depicted. One example had four spaces, even though the coding standards require 3 space indentation.
The editorconfig file was also incorrect.

Also fixed the order in which retro_init() and retro_set_*() should be called.