### PR TITLE
Added libx11-xcb-dev to required depencies for Debian/Ubuntu

### DIFF
--- a/docs/development/retroarch/compilation/linux-and-bsd.md
+++ b/docs/development/retroarch/compilation/linux-and-bsd.md
@@ -24,7 +24,7 @@ sudo dnf install make automake gcc gcc-c++ kernel-devel mesa-libEGL-devel libv4l
 
 #### Satisfying dependencies under Debian/Ubuntu
 ```bash
-apt-get -y install build-essential libxkbcommon-dev zlib1g-dev libfreetype6-dev libegl1-mesa-dev libgles2-mesa-dev libgbm-dev nvidia-cg-toolkit nvidia-cg-dev libavcodec-dev libsdl2-dev libsdl-image1.2-dev libxml2-dev yasm
+apt-get -y install build-essential libxkbcommon-dev zlib1g-dev libfreetype6-dev libegl1-mesa-dev libgles2-mesa-dev libgbm-dev nvidia-cg-toolkit nvidia-cg-dev libavcodec-dev libsdl2-dev libsdl-image1.2-dev libxml2-dev yasm libx11-xcb-dev
 ```
 
 #### Satisfying dependencies under Alpine


### PR DESCRIPTION
Without this dependency compiling on Ubuntu 20.04 amd64 returns:

```
[..]
LD retroarch  
/usr/bin/ld: cannot find -lX11-xcb
```

**Note 1**: This issue was reported to [Debian maintainers](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=949282).
**Note 2**: I have not checked the testing/stable PPAs