### PR TITLE
Updated "Beetle Handy" to "Beetle Lynx" in all pages

### DIFF
--- a/docs/development/licenses.md
+++ b/docs/development/licenses.md
@@ -63,7 +63,7 @@ See below for a summary of the licenses behind RetroArch and its cores:
 | [Beetle bsnes](../library/beetle_bsnes.md)       			           | [GPLv2](https://github.com/libretro/beetle-bsnes-libretro/blob/master/COPYING)            |                |
 | [Beetle Cygne](../library/beetle_cygne.md)       			           | [GPLv2](https://github.com/libretro/beetle-wswan-libretro/blob/master/COPYING)            |                |
 | [Beetle GBA](../library/beetle_gba.md)           			           | [GPLv2](https://github.com/libretro/beetle-gba-libretro/blob/master/COPYING)              |                |
-| [Beetle Handy](../library/beetle_handy.md)        			           | [zlib](https://github.com/libretro/beetle-lynx-libretro/blob/master/mednafen/lynx/license.txt), [GPLv2](https://github.com/libretro/beetle-lynx-libretro/blob/master/COPYING)       |                |
+| [Beetle Lynx](../library/beetle_lynx.md)        			           | [zlib](https://github.com/libretro/beetle-lynx-libretro/blob/master/mednafen/lynx/license.txt), [GPLv2](https://github.com/libretro/beetle-lynx-libretro/blob/master/COPYING)       |                |
 | [Beetle NeoPop](../library/beetle_neopop.md)        			           | [GPLv2](https://github.com/libretro/beetle-ngp-libretro/blob/master/COPYING)              |                |
 | [Beetle PC-FX](../library/beetle_pc_fx.md)        			           | [GPLv2](https://github.com/libretro/beetle-pcfx-libretro/blob/master/COPYING)             |                |
 | [Beetle PCE FAST](../library/beetle_pce_fast.md) 			           | [GPLv2](https://github.com/libretro/beetle-pce-fast-libretro/blob/master/COPYING)         |                |

--- a/docs/guides/retroachievements.md
+++ b/docs/guides/retroachievements.md
@@ -75,7 +75,7 @@ You can also check the progress of your friends and add comments on their trophi
 
 | Core                                                             | Supported | Notes |
 |------------------------------------------------------------------|:---------:|:------|
-| [Beetle Handy](https://github.com/libretro/beetle-lynx-libretro) | ✔         | Also known as Beetle Lynx |
+| [Beetle Lynx](https://github.com/libretro/beetle-lynx-libretro)  | ✔         |       |
 | [Handy](https://github.com/libretro/libretro-handy)              | ✔         |       |
 
 ### Bandai

--- a/docs/library/beetle_lynx.md
+++ b/docs/library/beetle_lynx.md
@@ -1,4 +1,4 @@
-# Atari - Lynx (Beetle Handy)
+# Atari - Lynx (Beetle Lynx)
 
 ## Background
 
@@ -6,12 +6,12 @@ Beetle Lynx is an Atari Lynx video game system emulator that can be used as a li
 
 ### Author/License
 
-The Beetle Handy core has been authored by
+The Beetle Lynx core has been authored by
 
 - K. Wilkins
 - [Mednafen Team](https://mednafen.github.io/)
 
-The Beetle Handy core is licensed under
+The Beetle Lynx core is licensed under
 
 - [zlib](https://github.com/libretro/beetle-lynx-libretro/blob/master/mednafen/lynx/license.txt), [GPLv2](https://github.com/libretro/beetle-lynx-libretro/blob/master/COPYING)
 
@@ -19,14 +19,14 @@ A summary of the licenses behind RetroArch and its cores have found [here](https
 
 ## Extensions
 
-Content that can be loaded by the Beetle Handy core have the following file extensions:
+Content that can be loaded by the Beetle Lynx core have the following file extensions:
 
 - .lnx
 - .o
 
 ## Databases
 
-RetroArch database(s) that are associated with the Beetle Handy core:
+RetroArch database(s) that are associated with the Beetle Lynx core:
 
 - [Atari - Lynx](https://github.com/libretro/libretro-database/blob/master/rdb/Atari%20-%20Lynx.rdb)
 
@@ -40,7 +40,7 @@ Required or optional firmware files go in the frontend's system directory.
 
 ## Features
 
-Frontend-level settings or features that the Beetle Handy core respects.
+Frontend-level settings or features that the Beetle Lynx core respects.
 
 | Feature           | Supported |
 |-------------------|:---------:|
@@ -71,9 +71,9 @@ Frontend-level settings or features that the Beetle Handy core respects.
 
 ### Directories
 
-The Beetle Handy core's directory name is 'Beetle Lynx'
+The Beetle Lynx core's directory name is 'Beetle Lynx'
 
-The Beetle Handy core saves/loads to/from these directories.
+The Beetle Lynx core saves/loads to/from these directories.
 
 **Frontend's State directory**
 
@@ -81,17 +81,17 @@ The Beetle Handy core saves/loads to/from these directories.
 
 ### Geometry and timing
 
-- The Beetle Handy core's core provided FPS is 75
-- The Beetle Handy core's core provided sample rate is 44100 Hz
-- The Beetle Handy core's core provided aspect ratio is 80/51
+- The Beetle Lynx core's core provided FPS is 75
+- The Beetle Lynx core's core provided sample rate is 44100 Hz
+- The Beetle Lynx core's core provided aspect ratio is 80/51
 
 ## Loading content
 
-Beetle Handy supports Lynx headered roms and non-headered roms. It also supports homebrews in *.o extensions.
+Beetle Lynx supports Lynx headered roms and non-headered roms. It also supports homebrews in *.o extensions.
 
 ## Core options
 
-The Beetle Handy core has the following option(s) that can be tweaked from the core options menu. The default setting is bolded. 
+The Beetle Lynx core has the following option(s) that can be tweaked from the core options menu. The default setting is bolded. 
 
 Settings with (Restart) means that core has to be closed for the new setting to be applied on next launch.
 
@@ -102,7 +102,7 @@ Settings with (Restart) means that core has to be closed for the new setting to 
 
 ## Controllers
 
-The Beetle Handy core supports the following device type(s) in the controls menu, bolded device types are the default for the specified user(s):
+The Beetle Lynx core supports the following device type(s) in the controls menu, bolded device types are the default for the specified user(s):
 
 ### User 1 device types
 
@@ -116,7 +116,7 @@ The Beetle Handy core supports the following device type(s) in the controls menu
 
 #### Joypad
 
-| User 1 Remap descriptors | RetroPad Inputs                                | Beetle Handy core inputs |
+| User 1 Remap descriptors | RetroPad Inputs                                | Beetle Lynx core inputs |
 |--------------------------|------------------------------------------------|--------------------------|
 |                          | ![](/image/retropad/retro_b.png)             | B                        |
 |                          | ![](/image/retropad/retro_start.png)         | Pause                    |
@@ -143,9 +143,9 @@ Supported combinations
 
 - [Official Mednafen Website](https://mednafen.github.io/)
 - [Official Mednafen Downloads](https://mednafen.github.io/releases/)
-- [Libretro Beetle Handy Core info file](https://github.com/libretro/libretro-super/blob/master/dist/info/mednafen_lynx_libretro.info)
-- [Libretro Beetle Handy Github Repository](https://github.com/libretro/beetle-lynx-libretro)
-- [Report Libretro Beetle Handy Core Issues Here](https://github.com/libretro/beetle-lynx-libretro/issues)
+- [Libretro Beetle Lynx Core info file](https://github.com/libretro/libretro-super/blob/master/dist/info/mednafen_lynx_libretro.info)
+- [Libretro Beetle Lynx Github Repository](https://github.com/libretro/beetle-lynx-libretro)
+- [Report Libretro Beetle Lynx Core Issues Here](https://github.com/libretro/beetle-lynx-libretro/issues)
 
 ### See also
 

--- a/docs/library/bios.md
+++ b/docs/library/bios.md
@@ -60,7 +60,7 @@ GameBoy Advance               | mGBA               | [BIOS information](https://
 GameBoy Advance               | VBA Next           | [BIOS information](https://docs.libretro.com/library/vba_next/#bios)
 Gamecube/Wii                  | Dolphin            | [BIOS information](https://docs.libretro.com/library/dolphin/#bios)
 Intellivision                 | FreeIntv           | [BIOS information](https://docs.libretro.com/library/freeintv/#bios)
-Lynx                          | Beetle Handy       | [BIOS information](https://docs.libretro.com/library/beetle_handy/#bios)
+Lynx                          | Beetle Lynx        | [BIOS information](https://docs.libretro.com/library/beetle_lynx/#bios)
 Lynx                          | Handy              | [BIOS information](https://docs.libretro.com/library/handy/#bios)
 Master System                 | Emux SMS           | [BIOS information](https://docs.libretro.com/library/emux_sms/#bios)
 MS/GG                         | SMS Plus GX        | [BIOS information](https://docs.libretro.com/library/smsplus/#bios)

--- a/docs/library/compatibility/lynx.md
+++ b/docs/library/compatibility/lynx.md
@@ -6,10 +6,7 @@
 |------------------|-------------------------------------------------------------------------|
 |  RoadBlasters  | Graphics glitches. Minor flickering and glitches after starting a race. |
 
-## Beetle Handy
-
-!!! attention
-	Beetle Handy is incompatible with modern No-Intro romsets as they require headers to work properly. The regular Handy core does not have this issue.
+## Beetle Lynx
 
 | Game             | Issue                                                                   |
 |------------------|-------------------------------------------------------------------------|

--- a/docs/library/handy.md
+++ b/docs/library/handy.md
@@ -144,4 +144,4 @@ Supported combinations
 
 #### Atari - Lynx
 
-- [Atari - Lynx (Beetle Handy)](https://docs.libretro.com/library/beetle_handy/)
+- [Atari - Lynx (Beetle Lynx)](https://docs.libretro.com/library/beetle_lynx/)

--- a/docs/meta/core-list.md
+++ b/docs/meta/core-list.md
@@ -6,7 +6,7 @@
 - Beetle Cygne
 - BeetleDC
 - Beetle GBA
-- Beetle Handy
+- Beetle Lynx
 - Beetle NeoPop
 - Beetle PC-FX
 - Beetle PCE FAST

--- a/docs/meta/see-also.md
+++ b/docs/meta/see-also.md
@@ -9,7 +9,7 @@ This is a list of cores that are related to each other in some way.
 
 ## Lynx
 
-- [Atari - Lynx (Beetle Handy)](https://docs.libretro.com/library/beetle_handy/)
+- [Atari - Lynx (Beetle Lynx)](https://docs.libretro.com/library/beetle_lynx/)
 - [Atari - Lynx (Handy)](https://docs.libretro.com/library/handy/)
 
 ## MSX

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -88,7 +88,7 @@ nav:
         - 'Atari - 7800 (ProSystem)': 'library/prosystem.md'
         - 'Atari - 5200 (Atari800)': 'library/atari800.md'
         - 'Atari - Jaguar (Virtual Jaguar)': 'library/virtual_jaguar.md'
-        - 'Atari - Lynx (Beetle Handy)': 'library/beetle_handy.md'
+        - 'Atari - Lynx (Beetle Lynx)': 'library/beetle_lynx.md'
         - 'Atari - Lynx (Handy)': 'library/handy.md'
         - 'Atari - ST/STE/TT/Falcon (Hatari)': 'library/hatari.md'
       - 'Bandai Emulation':


### PR DESCRIPTION
Name was updated in libretro/libretro-super@9a2a5b6. In all other non-docs locations it was already Beetle Lynx.