### PR TITLE
Remove duplicate link

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -44,4 +44,3 @@ You can see a list sorted by hardware maker under *For Users > Core Library: Emu
 - [Steam](https://store.steampowered.com/app/1118310/RetroArch/)
 - [Steam Group](https://steamcommunity.com/groups/libretro)
 - [Steam Developer Page](https://store.steampowered.com/developer/libretro)
-- [Steam](https://store.steampowered.com/app/1118310/RetroArch/)


### PR DESCRIPTION
Saw that the [Steam](https://store.steampowered.com/app/1118310/RetroArch/) link had been duplicated on [the website](https://docs.libretro.com/). I assumed you would want one of them removed, probably the bottom one 😄 