### PR TITLE
NetPlay: Fix links, separate FAQ from troubleshooting, etc.

### DIFF
--- a/docs/guides/netplay-faq.md
+++ b/docs/guides/netplay-faq.md
@@ -5,27 +5,27 @@
 
 ### What is netplay?
 
-- It's a mechanism that allows multiplayer over a network. It's not link cable emulation though. It's same system multiplayer.
+- Netplay is RetroArch's mechanism for emulating local multiplayer over the internet, by continuously synchronizing multiple RetroArch instances running the same emulation core and same content. Currently, this approach is only for emulating classic single-system local multiplayer, not link cable play or network multiplayer modes.
 
 ### Does RetroArch require port-forwarding to work?
 
-- Yes, the host needs to forward the ports properly. There is a fallback mechanism that can be employed by those who can't forward the ports, please read the Setup Guide below.
+- The host needs to accept incoming connections on port TCP 55435. For most people, this requires port-forwarding: the network connections have to be forwarded from your local network access point (i.e. gateway or router) to the device running RetroArch. RetroArch requests a port-forwarding from the local network using the UPnP IGD protocol, or, you can manually create a port-forwarding rule on your network device. For those who can't forward the ports for whatever reason, please refer to the Setup Guide below.
 
 ### Does it support more than two players?
 
-- Yes! See [Getting Started Guide](netplay-getting-started) for more details.
+- Yes! See [Getting Started Guide](netplay-getting-started.md) for more details.
 
 ### Does it support more than one player on one computer?
 
-- Yes! See [Mutliple Controllers Guide](netplay-multiple-controllers) for more details.
+- Yes! See [Mutliple Controllers Guide](netplay-multiple-controllers.md) for more details.
+
+### Does it support the host spectating while a client performs as player 1?
+
+- Yes! By default, the host is always assigned Controller 1, but see [Mutliple Controllers Guide](netplay-multiple-controllers.md) on how a client can 'Request Device' to be controller 1.
 
 ### What do you need for RetroArch netplay to work?
 
 - Same RetroArch version, same core version, and the same exact content.
-
-### RetroArch says *Content not found, try loading content manually*
-
-- Either load content manually, have the content in your recent history list, or scan your content to a playlist.
 
 ### Does RetroArch support cross-platform netplay?
 
@@ -46,3 +46,17 @@
 ### Can I trade Pokémon via RetroArch Netplay?
 
 - No.
+
+## Troubleshooting NetPlay
+
+### RetroArch says "Content not found, try loading content manually"
+
+- Either load content manually, have the content in your recent history list, or scan your content to a playlist.
+
+### As Client: "Failed to Initialize Netplay"
+
+"Failed to Initialize Netplay" often means you were not able to connect to the host. Confirm that you have the correct IP address for the host, and that the host has begun hosting a NetPlay session. Tell the host to check if their host-based firewall is allowing RetroArch to accept connections, and confirm that they have port-forwarding working.
+
+### As Host: "Port Mapping Failed"
+
+"Port Mapping Failed" probably indicates a UPnP port-forwarding problem. If you can manually configure your network gateway to forward TCP port 55435 to the local-network IP address of your RetroArch device, then you can do that. Alternatively, enable the use of a Relay Server.

--- a/docs/guides/netplay-getting-started.md
+++ b/docs/guides/netplay-getting-started.md
@@ -3,7 +3,8 @@
 
 ## Getting Started
 
-### Configuring Nickname
+### Configure a Nickname
+
 - Navigate to **Settings**
 - Navigate to **User**
 - Select **Username**
@@ -11,25 +12,24 @@
 
 ![Screenshot](../image/retroarch/netplay/nickname.png)
 
-### Configure Netplay Server
+### Host a Netplay Server
 
-If you are gonna host a game you don't need to scan content or to build databases. The only thing you need to do is to configure your network parameters and "Start Hosting" from the netplay menu. After doing that just load the content you want to netplay and wait for players.
+If you are going to host a game, simply configure your network parameters and "Start Hosting" from the netplay menu. After doing that, load the content you want to netplay and wait for players to connect.
 
 ![Screenshot](../image/retroarch/netplay/netplay.jpg)
 
 #### Check your lobby
 
-Once you start hosting you can check to see if your lobby is visible [at lobby.libretro.com](http://lobby.libretro.com/).
+Once you start hosting, you can check to see if your lobby is visible [at lobby.libretro.com](http://lobby.libretro.com/).
 
 !!! tip
-    If your router doesn't support UPnP or you can't forward your ports or you are uncertain, enable the **Use Relay Server** option. This routes both sides of the connection through our man-in-the-middle server.
+    If your router doesn't support UPnP, you can't forward your ports, or you are just uncertain how, enable the **Use Relay Server** option. This routes both sides of the connection through one of the public proxy servers.
 
 !!! tip
-    If you want to run a private game you can setup a **Server Password** to prevent random people from connecting. Alternatively you can disable the **Publicly Announce Netplay** option. The clients will need to enter your IP address or hostname directly.
+    If you want to run a private game, set up a **Server Password** to prevent random people from connecting. Alternatively, you can disable the **Publicly Announce Netplay** option. The clients will need to enter your IP address or hostname directly.
 
 !!! Warning
-    RetroArch doesn't check if you managed to open your ports manually, the lobby server doesn't either so make sure you do that properly or enable the Relay Server or people won't be able to connect to your session. You can use [this tool](http://www.yougetsignal.com/tools/open-ports/), enter your **Netplay TCP Port** once you are hosting and it will tell you if the port is open or not.
-
+    By default, RetroArch attempts to use UPnP to automatically port-forward (it asks the gateway to forward incoming connections on TCP 55435 to itself), but it doesn't check to see if it succeeded (i.e., if it is actually reachable on TCP 55435 from elsewhere on the internet). The lobby server doesn't verify the host's reachability either. Make sure you have correctly port-forwarded, using [this tool](http://www.yougetsignal.com/tools/open-ports/): enter your **Netplay TCP Port** once you are hosting, and it will tell you if the port is open or not. If this port is not open, people won't be able to connect to your session, and you might have to enable the use of a Relay Server.
 
 ### Configure Netplay Clients
 
@@ -37,8 +37,7 @@ You don't need to configure anything to connect to netplay rooms. Browse to the 
 
 ![Screenshot](../image/retroarch/netplay/rooms.png)
 
-You will be asked for a password if one is required, and if you have matching content scanned or in the **Content History** it will connect right away. Otherwise it will tell you to load the core and content manually and it will attempt to connect right away.
-
+You will be asked for a password if one is required, and if you have matching content scanned or in the **Content History** it will connect right away. Otherwise, it will tell you to load the core and content manually and it will attempt to connect right away.
 
 #### Video Tutorial
 

--- a/docs/guides/netplay-multiple-controllers.md
+++ b/docs/guides/netplay-multiple-controllers.md
@@ -1,44 +1,46 @@
 
 ![](../image/branding/netplay-logo.gif)
 
-## Setup Multiple Controllers on One (1) Computer
+## Assigning Controllers During Netplay
 
-###Request Device
+### Request Device
 
-**Request Device** is an advance network option used for NetPlay. **Request Device** allows the computer to request device(s)/controller(s) to control. This allows the capablitiy to allow two (2) computers with four (4) players. To make this option visible, RetroArch must have **Show Advanced Settings** set to _ON_.
+**Request Device** is an advanced network option used for NetPlay, that allows each RetroArch instance to request which device(s)/controller(s) to control. This, for example, enables four players from two instances of RetroArch, or for a connecting client to request the player 1 controller from the host. To make this option visible, RetroArch must have **Show Advanced Settings** set to _ON_.
 
-###Turning on **Show Advanced Settings**:
+#### Turning on **Show Advanced Settings**
+
 - Navigate to **Settings**
 - Navigate to **User Interface**
 - Toggle **Show Advanced Settings** to _ON_
 
-Once **Show Advanced Settings** is on, proceed to the **Network** configurations in the **Settings** menu (**NetPlay** menu also has a path to **Network** configurations). Scroll down through **Network** configuration, and the advance configuration options are now visible. **Request Device #** _(where # is any number from 1 to 16)_ options will allow the computer to control two (2) or more controllers.
+Once **Show Advanced Settings** is on, proceed to the **Network** configurations in the **Settings** menu (**NetPlay** menu also has a path to **Network** configurations). Scroll down through **Network** configuration, and the advanced configuration options are now visible. **Request Device #** _(where # is any number from 1 to 16)_ options will allow the computer to control any number of controllers during NetPlay.
 
-##Setup Guide
+## Example Setup: Step-by-Step Guide
 
-The following example of Super Bomberman 2 on the SNES will be used to demonstrate four (4) players using two (2) computers. The host will be controlling players one (1) and three (3), and the client will be controlling players two (2) and four (4).
+The following example of Super Bomberman 2 on the SNES will be used to demonstrate four players using two computers. The host will be controlling players 1 and 3, and the client will be controlling players 2 and 4.
 
-### Host
-#### Input Devices
+### On the Host
+
+#### Configure Host's Input Devices
 
 Set up **Input Devices** while the game is loaded:
 
-- Connect two (2) controllers
+- Connect two controllers
 - Start SNES Super Bomberman 2 game
 - Set **Inputs** for each controller 1 and 2:
-    - Navigate to **Settings**
-    - Navigate to **Inputs**
-    - Navigate to **Port 1 Binds**
-    - Ensure **Device Index** is set to *_Controller Name 1_
-    - Return to **Inputs** configuration menu
-    - Navigate to **Port 2 Binds**
-    - Ensure **Device Index** is set to *_Controller Name 2_
-    - Set **Device Type** to _MultiTap_
-        - _MultiTap_ is only available when SNES core is loaded. This plugs in a virtual SNES MultiTap into the SNES so more than two (2) controllers can connect to the SNES.
+  - Navigate to **Settings**
+  - Navigate to **Inputs**
+  - Navigate to **Port 1 Binds**
+  - Ensure **Device Index** is set to *_Controller Name 1_
+  - Return to **Inputs** configuration menu
+  - Navigate to **Port 2 Binds**
+  - Ensure **Device Index** is set to *_Controller Name 2_
+  - Set **Device Type** to _MultiTap_
+    - _MultiTap_ is only available when SNES core is loaded. This plugs in a virtual SNES MultiTap into the SNES so more than two controllers can connect to the SNES.
 
-    \* Controller Name 1 and 2 are unique to the computer and to the controllers connected to it (e.g. PS4 controller shows as "Wireless Controller \#1")
+    \* Controller Name 1 and 2 are unique to the computer and to the controllers connected to it (_e.g._, PS4 controller shows as "Wireless Controller \#1")
 
-#### Network Request Device
+#### Configure Host's Requested Devices
 
 Set host computer's RetroArch NetPlay to request control of the running core's devices/controllers:
 
@@ -48,29 +50,30 @@ Set host computer's RetroArch NetPlay to request control of the running core's d
 - Set **Request Device 3** to _YES_
 - Ensure all other **Request Device #** are set to _NO_
 
-Host is now able to start a NetPlay game controlling controllers one (1) and three (3). See [Getting Started Guide](netplay-getting-started) for more details.
+Host is now able to start a NetPlay game controlling controllers 1 and 3. See [Getting Started Guide](netplay-getting-started.md) for more details.
 
 ![Screenshot](../image/retroarch/netplay/netplay_multiple_controllers_host.png)
 
-###Client
-#### Input Devices
+### Client
+
+#### Configure Client's Input Devices
 
 Set up **Input Devices** while the game is loaded:
 
-- Connect two (2) controllers
+- Connect two controllers
 - Start SNES Super Bomberman 2 game
 - Set **Inputs** for each controller 1 and 2:
-    - Navigate to **Settings**
-    - Navigate to **Inputs**
-    - Navigate to **Port 1 Binds**
-    - Ensure **Device Index** is set to *_Controller Name 1_
-    - Return to **Inputs** configuration menu
-    - Navigate to **Port 2 Binds**
-    - Ensure **Device Index** is set to *_Controller Name 2_
+  - Navigate to **Settings**
+  - Navigate to **Inputs**
+  - Navigate to **Port 1 Binds**
+  - Ensure **Device Index** is set to *_Controller Name 1_
+  - Return to **Inputs** configuration menu
+  - Navigate to **Port 2 Binds**
+  - Ensure **Device Index** is set to *_Controller Name 2_
 
-    \* Controller Name 1 and 2 are unique to the computer and to the controllers connected to it (e.g. PS4 controller shows as "Wireless Controller \#1")
+    \* Controller Name 1 and 2 are unique to the computer and to the controllers connected to it (_e.g._, PS4 controller shows as "Wireless Controller \#1")
 
-#### Network Request Device
+#### Configure Client's Requested Devices
 
 Set client computer's RetroArch Netplay to request control of the running core's devices/controllers:
 
@@ -80,11 +83,9 @@ Set client computer's RetroArch Netplay to request control of the running core's
 - Set **Request Device 3** to _YES_
 - Ensure all other **Request Device #** are set to _NO_
 
-Client is now able to join the host in a NetPlay game controlling controllers two (2) and four (4). See [Getting Started Guide](netplay-getting-started) for more details.
+Client is now able to join the Host in a NetPlay game controlling controllers 2 and 4. See the [Getting Started Guide](netplay-getting-started.md) for more details.
 
 ![Screenshot](../image/retroarch/netplay/netplay_multiple_controllers_client.png)
 
-
 !!! Warning
-    RetroArch **Network** typically has all **Request Device #** set to _NO_. When all **Request Device #** are set to _NO_, this allows NetPlay to automatically set host as device/controller one (1). Then when the client connects to the host, the client will connect to device/controller two (2) for the NetPlay session. Each subsequent client that connects will continue connect to the next available device/controller.
-    RetroArch NetPlay requires all **Request Device #** set to _NO_ for RetroArch Netplay to automatically assign device/controller for the NetPlay session.
+    RetroArch **Network** typically has all **Request Device #** set to _NO_. When all **Request Device #** are set to _NO_, this allows NetPlay to automatically set host as device/controller 1. When the client connects to the host, the client will connect to device/controller 2 for the NetPlay session. Each subsequent client that connects will continue connect to the next available device/controller. For this automatic client-to-controller assignment in a RetroArch NetPlay session to work, all **Request Device #** settings must be set to _NO_. If any connecting clients request a device, automatic assignment is disabled for everyone and all clients must request a device via the settings menu.


### PR DESCRIPTION
In #netplay on the RetroArch Discord, user @gnutjs reported that the NetPlay docs pages could be better. I have been using NetPlay a lot recently and agree. Here's my first take at some docs improvements.

- Fix the links that needed the `.md` file extension on the link target
- Better explain a couple of things
- Break out a section of the FAQ for troubleshooting common issues

There are some "missing stair" bugs right now like RetroArch clients losing their audio, but I opted not to mention things like that in the docs.