### PR TITLE
Add CLI intro tip for macOS users

### DIFF
--- a/docs/guides/cli-intro.md
+++ b/docs/guides/cli-intro.md
@@ -6,7 +6,7 @@ Note: please be aware of whether your system uses DOS/Windows style paths with b
 
 [![Quick Video Demonstration for Windows](http://img.youtube.com/vi/W-fRcamSp-c/0.jpg)](http://www.youtube.com/watch?v=W-fRcamSp-c)
 
-#### On macOS: Invoking the RetroArch CLI executable
+#### On macOS: invoking the RetroArch CLI executable
     /Applications/RetroArch.app/Contents/MacOS/RetroArch
 
 #### Example: loading a ROM and libretro core (Unix-style path)

--- a/docs/guides/cli-intro.md
+++ b/docs/guides/cli-intro.md
@@ -1,18 +1,20 @@
 # RetroArch CLI
 
-RetroArch can be utilized via its robust graphical interfaces as well as a powerful command-line interface (CLI). Getting familiar with the command-line helps you understand the design principles of RetroArch.
+RetroArch can be used from its robust graphical interfaces as well as a powerful command-line interface (CLI). Getting familiar with the command-line helps you understand the design principles of RetroArch.
 
 Note: please be aware of whether your system uses DOS/Windows style paths with backslashes `\` or Unix-style paths with forward slashes: `/`.
 
 [![Quick Video Demonstration for Windows](http://img.youtube.com/vi/W-fRcamSp-c/0.jpg)](http://www.youtube.com/watch?v=W-fRcamSp-c)
 
-#### Loading a ROM and libretro core (Unix-style path)
+#### On macOS: Invoking the RetroArch CLI executable
+    /Applications/RetroArch.app/Contents/MacOS/RetroArch
+
+#### Example: loading a ROM and libretro core (Unix-style path)
     retroarch -L /path/to/libretro/core.so game.rom
 
-#### Loading a ROM and libretro core with flatpak
+#### Example: loading a ROM and libretro core with flatpak
     retroarch -L /path/to/libretro/core.so game.rom
     flatpak run org.libretro.RetroArch/x86_64/stable -L /home/MYUSERNAME/.var/app/org.libretro.RetroArch/config/retroarch/cores/nestopia_libretro.so Tetris.nes
-
 
 ## Verbose logging output
 To get a better idea on what's going on, use the `--verbose` flag. If you want to report a bug, it is **vital** that this log is included.
@@ -20,7 +22,7 @@ To get a better idea on what's going on, use the `--verbose` flag. If you want t
 ## Using a config file
 By default, RetroArch looks for a config in various places depending on OS:
 
-- **Linux/OSX**: `$XDG_CONFIG_HOME/retroarch/retroarch.cfg`, then `~/.config/retroarch/retroarch.cfg`, then `~/.retroarch.cfg`, and finally, as a fallback, `/etc/retroarch.cfg`.
+- **Linux/macOS**: `$XDG_CONFIG_HOME/retroarch/retroarch.cfg`, then `~/.config/retroarch/retroarch.cfg`, then `~/.retroarch.cfg`, and finally, as a fallback, `/etc/retroarch.cfg`.
 - **Windows**: `retroarch.cfg` in same folder as `retroarch.exe`, then `%APPDATA%\retroarch.cfg`.
 
 To override this, use `retroarch --config customconfig.cfg`. If you have some special options you want to store in separate config files, you can use `retroarch --config baseconfig.cfg --appendconfig specialconfig.cfg`. Be sure to pass `--menu` as well if you aren't loading content directly from the command-line, or RetroArch will close immediately after launching. See man-page and/or `--help` for detail.


### PR DESCRIPTION
Intermediate macOS users may want to try the CLI features of RetroArch, but not be familiar with how to invoke a CLI app within a macOS app bundle. So I just added a tip here.