### PR TITLE
Add note about no docs for OpenDingux logging

### DIFF
--- a/docs/guides/generating-retroarch-logs.md
+++ b/docs/guides/generating-retroarch-logs.md
@@ -140,6 +140,9 @@ At the moment there are no logging docs available for other Nintendo consoles. P
 ### Generating Logs with PlayStation Consoles
 At the moment there are no logging docs available for PlayStation consoles. Please feel free to post about your situation in the libretro forums.
 
+### Generating Logs in OpenDingux (GCW-Zero and RG350)
+At the moment there are no logging docs available for OpenDingux. Please feel free to post about your situation in the libretro forums.
+
 
 -------------------------
 


### PR DESCRIPTION
Can't find authoritative docs on how to enable logging on the OpenDingux build. Added a note that there are no docs available.