### PR TITLE
Update Qt instructions in Windows compilation guide

### DIFF
--- a/docs/development/retroarch/compilation/windows.md
+++ b/docs/development/retroarch/compilation/windows.md
@@ -152,7 +152,7 @@ for i in $(seq 3); do for bin in $(ntldd -R *exe | grep -i mingw | cut -d">" -f2
 If Qt is enabled for your build (detected automatically by default), the following is also needed:
 
 ```bash
-windeployqt --release --no-patchqt --no-translations retroarch.exe
+windeployqt --no-patchqt --no-translations retroarch.exe
 for i in $(seq 3); do for bin in $(ntldd -R imageformats/*dll | grep -i mingw | cut -d">" -f2 | cut -d" " -f2); do cp -vu "$bin" . ; done; done
 ```
 


### PR DESCRIPTION
Due to a change introduced in Qt starting from 5.14.1 onwards, using the ` --release` or `--debug` flags with `windeployqt` will lead to an error when trying to run a self-built RA executable compiled through MSYS2/Mingw64 with Qt support.

This PR updates the build instructions for Windows, removing the --release flag from the corresponding script command provided in the guide.

See here for reference:
- https://bugreports.qt.io/browse/QTBUG-83167
- https://github.com/libretro/RetroArch/issues/10414