### PR TITLE
Added a checksum (naomi for flycast), changed a checksum (PSX Bios) Added a small note to Desmume

### DIFF
--- a/docs/library/desmume.md
+++ b/docs/library/desmume.md
@@ -38,7 +38,7 @@ Required or optional firmware files go in the frontend's system directory.
 
 !!! warning
 	In order for the firmware files to be loaded by the DeSmuME core, the 'Use External BIOS/Firmware (restart)' core option must be set to enabled.
-
+The md5sum of firmware.bin will vary from dump to dump. bios7 and bios9 should be the exact same as here. firmware.bin may not be the same.
 |   Filename   |    Description          |              md5sum              |
 |:------------:|:-----------------------:|:--------------------------------:|
 | firmware.bin | NDS Firmware - Optional | 145eaef5bd3037cbc247c213bb3da1b3 |

--- a/docs/library/flycast.md
+++ b/docs/library/flycast.md
@@ -87,7 +87,7 @@ Required or optional firmware files go in RetroArch's system directory.
 |:---------------:|:------------------------------------------------------------------:|:--------------------------------:|
 | dc/dc_boot.bin  | Dreamcast BIOS - Requried for Dreamcast                            | e10c53c2f8b90bab96ead2d368858623 |
 | dc/dc_flash.bin | Date/Time/Language - Required for Dreamcast                        | 0a93f7940c455905bea6e392dfde92a4 |
-| dc/naomi.zip    | Naomi Bios from MAME - Optional                                    | 391f8dcf1b69481df2dd8c1e90aae1a9 |
+| dc/naomi.zip    | Naomi Bios from MAME - Optional                                    |                                  |
 | dc/hod2bios.zip | Naomi The House of the Dead 2 Bios from MAME - Optional            |                                  |
 | dc/f355dlx.zip  | Naomi Ferrari F355 Challenge deluxe Bios from MAME - Optional      |                                  |
 | dc/f355bios.zip | Naomi Ferrari F355 Challenge twin/deluxe Bios from MAME - Optional |                                  |

--- a/docs/library/flycast.md
+++ b/docs/library/flycast.md
@@ -87,7 +87,7 @@ Required or optional firmware files go in RetroArch's system directory.
 |:---------------:|:------------------------------------------------------------------:|:--------------------------------:|
 | dc/dc_boot.bin  | Dreamcast BIOS - Requried for Dreamcast                            | e10c53c2f8b90bab96ead2d368858623 |
 | dc/dc_flash.bin | Date/Time/Language - Required for Dreamcast                        | 0a93f7940c455905bea6e392dfde92a4 |
-| dc/naomi.zip    | Naomi Bios from MAME - Optional                                    |                                  |
+| dc/naomi.zip    | Naomi Bios from MAME - Optional                                    | 391f8dcf1b69481df2dd8c1e90aae1a9 |
 | dc/hod2bios.zip | Naomi The House of the Dead 2 Bios from MAME - Optional            |                                  |
 | dc/f355dlx.zip  | Naomi Ferrari F355 Challenge deluxe Bios from MAME - Optional      |                                  |
 | dc/f355bios.zip | Naomi Ferrari F355 Challenge twin/deluxe Bios from MAME - Optional |                                  |

--- a/docs/library/pcsx_rearmed.md
+++ b/docs/library/pcsx_rearmed.md
@@ -28,7 +28,7 @@ Required or optional firmware files go in the frontend's system directory.
 | scph101.bin   | Version 4.4 03/24/00 A | 6E3735FF4C7DC899EE98981385F6F3D0 |
 | scph7001.bin  | Version 4.1 12/16/97 A | 1e68c231d0896b7eadcad1d7d8e76129 |
 | scph5501.bin  | Version 3.0 11/18/96 A | 490f666e1afb15b7362b406ed1cea246 |
-| scph1001.bin  | Version 2.0 05/07/95 A | dc2b9bf8da62ec93e868cfd29f0d067d |
+| scph1001.bin  | Version 2.0 05/07/95 A | 924e392ed05558ffdb115408c263dccf |
 
 In the event that none of the above is found, PCSX_ReARMed will search for filenames starting with "scph" and use that instead.
 It doesnt seem to matter whatever bios version is used and from what region as long as its from a retail psx/ps-one.


### PR DESCRIPTION
There was no md5sum for naomi.zip (flycast emulator), and I found a working naomi bios so I added that checksum.

The PSX Bios SCPH1001.BIN had an incorrect md5sum. I found SCPH1001.BIN from mulitple places, and they all had the same md5sum (924e392ed05558ffdb115408c263dccf). I also tested multiple games with SCPH1001.BIN (and NO other bios files) and they all worked fine, and the bootlogo appeared. (So I'm sure it wasn't using HLE.). This is for PSCX-ReArmed.

I also added a small note to Desmume about firmware.bin having different checksums from dump to dump. 

Thank's for taking the time to review this pull request, please ask any questions or address any concerns here. I love retroarch and would like to improve the wiki as much as possible (especially the PSX Bios thing, that annoyed me because I couldn't get it to work until I ignored it.)
