### PR TITLE
Updates to RetroAchievements guide and some cores

### DIFF
--- a/docs/guides/retroachievements.md
+++ b/docs/guides/retroachievements.md
@@ -53,7 +53,7 @@ You can also check the progress of your friends and add comments on their trophi
 
 | Core                                               | Supported | Notes |
 |----------------------------------------------------|:---------:|:------|
-| [FinalBurn Neo](https://github.com/libretro/FBNeo) | ✔         | AES bios is required for most Neo Geo achievements. AES Asia is generally English. |
+| [FinalBurn Neo](https://github.com/libretro/FBNeo) | ✔         | AES bios is required for many Neo Geo achievements. AES Asia (neo-epo.bin) is generally English. |
 | [MAME](https://github.com/libretro/mame)           | ✕         | Support is not likely to ever be possible. The same is true for all MAME variants. |
 
 ### Atari
@@ -157,7 +157,7 @@ You can also check the progress of your friends and add comments on their trophi
 
 | Core                                                    | Supported | Notes |
 |---------------------------------------------------------|:---------:|:------|
-| [QUASI88](https://github.com/libretro/quasi88-libretro) | ✔         | Some games may be unsupported in Retroarch due to missing options. Sets generally expect the MkIISR bios. Games should be run from within archives to prevent overwrite breaking achievement support [until a bug is fixed](https://github.com/libretro/quasi88-libretro/issues/44). |
+| [QUASI88](https://github.com/libretro/quasi88-libretro) | ✔         | Some games may be unsupported in Retroarch due to missing options. Sets generally expect the MkIISR bios. |
 
 ### Nintendo
 
@@ -207,7 +207,7 @@ You can also check the progress of your friends and add comments on their trophi
 | [Nestopia UE](https://github.com/libretro/nestopia)   | ✕         | [**Achievements are not fully supported yet**](https://github.com/libretro/docs/pull/10) |
 | [bnes](https://github.com/libretro/bnes-libretro)     | ✕         |       |
 | [Emux NES](https://github.com/libretro/emux)          | ✕         |       |
-| [FinalBurn Neo](https://github.com/libretro/FBNeo)    | ✕         | Requires games in `nes` or `fds` subdirectories, exact archives just like arcade. Not supported at this time. |
+| [FinalBurn Neo](https://github.com/libretro/FBNeo)    | ✔         | Requires games in `nes` or `fds` subdirectories, exact archives just like arcade. Not all games may be linked for this core. |
 
 #### Nintendo 64
 
@@ -264,7 +264,7 @@ You can also check the progress of your friends and add comments on their trophi
 | [SMS Plus GX](https://github.com/libretro/smsplus-gx)          | ✔         | Master System only |
 | [Gearsystem](https://github.com/drhelius/Gearsystem)           | ✔         |       |
 | [Emux SMS](https://github.com/libretro/emux)                   | ✕         |       |
-| [FinalBurn Neo](https://github.com/libretro/FBNeo)             | ✕         | Requires games in `megadriv` or `sms` subdirectories, exact archives just like arcade. Not supported at this time. |
+| [FinalBurn Neo](https://github.com/libretro/FBNeo)             | ✔         | Requires games in `megadriv` or `sms` subdirectories, exact archives just like arcade. Not all games may be linked for this core. |
 
 #### 32X / 32X CD
 
@@ -279,7 +279,7 @@ You can also check the progress of your friends and add comments on their trophi
 | [Genesis Plus GX](https://github.com/libretro/Genesis-Plus-GX) | ✔         |       |
 | [SMS Plus GX](https://github.com/libretro/smsplus-gx)          | ✔         |       |
 | [Gearsystem](https://github.com/drhelius/Gearsystem)           | ✔         |       |
-| [FinalBurn Neo](https://github.com/libretro/FBNeo)             | ✕         | Requires games in `gamegear` subdirectory, exact archives just like arcade. Not supported at this time. |
+| [FinalBurn Neo](https://github.com/libretro/FBNeo)             | ✔         | Requires games in `gamegear` subdirectory, exact archives just like arcade. Not all games may be linked for this core. |
 
 #### SG-1000
 
@@ -302,10 +302,10 @@ You can also check the progress of your friends and add comments on their trophi
 
 | Core                                                                | Supported | Notes |
 |---------------------------------------------------------------------|:---------:|:------|
-| [Beetle Saturn](https://github.com/libretro/beetle-saturn-libretro) | ✔         |       |
-| [Yabause](https://github.com/libretro/yabause)                      | ✔         |       |
+| [Beetle Saturn](https://github.com/libretro/beetle-saturn-libretro) | ✔         | High accuracy, but low speed |
+| [Yabause](https://github.com/libretro/yabause)                      | ✔         | Higher speed |
+| [Kronos](https://github.com/libretro/yabause)                       | ✔         | High speed, supports graphic enhancements, but requires a GPU that supports at least OpenGL 4.2 |
 | [Yabasanshiro](https://github.com/libretro/yabause)                 | ✕         |       |
-| [Kronos](https://github.com/libretro/yabause)                       | ✕         |       |
 
 ### SNK
 
@@ -315,7 +315,7 @@ You can also check the progress of your friends and add comments on their trophi
 |------------------------------------------------------------------|:---------:|:------|
 | [Beetle NeoPop](https://github.com/libretro/beetle-ngp-libretro) | ✔         |       |
 | [RACE](https://github.com/libretro/RACE)                         | ✔         |       |
-| [FinalBurn Neo](https://github.com/libretro/FBNeo)               | ✕         | Requires games in `ngp` subdirectory, exact archives just like arcade. Not supported at this time. |
+| [FinalBurn Neo](https://github.com/libretro/FBNeo)               | ✔         | Requires games in `ngp` subdirectory, exact archives just like arcade. Not all games may be linked for this core. |
 
 ### Sony
 
@@ -326,6 +326,7 @@ You can also check the progress of your friends and add comments on their trophi
 | [Beetle PSX HW](https://github.com/libretro/beetle-psx-libretro) | ✔         | Identical to Beetle PSX, with extra hardware features. High accuracy. |
 | [Beetle PSX](https://github.com/libretro/beetle-psx-libretro)    | ✔         | Identical to Beetle PSX HW in software mode. |
 | [DuckStation](https://github.com/stenzek/duckstation)            | ✔         | Fairly high accuracy, extremely high speed. |
+| [SwanStation](https://github.com/libretro/swanstation)           | ✔         | Forked from DuckStation, similar functionality. No longer receiving updates. |
 | [PCSX ReARMed](https://github.com/libretro/pcsx_rearmed)         | ✔         | Lower accuracy than Beetle PSX (HW), higher speed. |
 
 ### The 3DO Company (various manufacturers)

--- a/docs/library/beetle_pce_fast.md
+++ b/docs/library/beetle_pce_fast.md
@@ -124,6 +124,8 @@ After that, you can load the `foo.cue` file in RetroArch with the Beetle PCE FAS
 !!! warning ""
     Certain PC Engine content are multi-track, so their .cue files might be more complicated.
 
+ISO + OGG and ISO + WAV format games are supported, but they require a properly formatted cue sheet. For iso files, tracks should be denoted as BINARY, for ogg files, they should be denoted as OGG, and for wav files, they should be denoted as WAVE.
+
 ## CHD
 
 Alternatively to using cue sheets with .bin/.iso files, you can convert your games to .chd (MAME Compressed Hunks of Data) to reduce file sizes and neaten up your game folder.

--- a/docs/library/beetle_sgx.md
+++ b/docs/library/beetle_sgx.md
@@ -123,6 +123,8 @@ After that, you can load the `foo.cue` file in RetroArch with the Beetle SuperGr
 !!! warning ""
     Certain PC Engine content are multi-track, so their .cue files might be more complicated.
 
+ISO + OGG and ISO + WAV format games are supported, but they require a properly formatted cue sheet. For iso files, tracks should be denoted as BINARY, for ogg files, they should be denoted as OGG, and for wav files, they should be denoted as WAVE.
+
 ## CHD
 
 Alternatively to using cue sheets with .bin/.iso files, you can convert your games to .chd (MAME Compressed Hunks of Data) to reduce file sizes and neaten up your game folder.

--- a/docs/library/genesis_plus_gx.md
+++ b/docs/library/genesis_plus_gx.md
@@ -152,7 +152,15 @@ Here's a cue file example done with Lunar - Eternal Blue (USA)
 ![](../image/core/genesis_plus_gx/cue.png)
 
 !!! warning ""
-	For Sega-CD games, ISO + WAV, BIN + CUE and ISO + OGG formats are supported; ISO + MP3 is not supported.
+	For Sega-CD games, ISO + WAV, BIN + CUE and ISO + OGG formats are supported; ISO + MP3 is not supported. Audio files must be in the 16-bit stereo 44100Hz format. If using a cue sheet, WAV or OGG tracks should be denoted as AUDIO.
+
+When loading ISO + WAV or ISO + OGG format games, the core will attempt to load a cue named the same as the iso first. If one is not found, the following audio track naming formats are accepted for a data track of "game.iso":
+
+- game02.ogg
+- game 02.ogg
+- game-02.ogg
+- game - 02.ogg
+- game_02.ogg
 
 ## Core options
 

--- a/docs/library/pcsx2.md
+++ b/docs/library/pcsx2.md
@@ -55,7 +55,7 @@ A summary of the licenses behind RetroArch and its cores can be found [here](../
 	Interesting fact: For maximum compatibility it is recommended that you use a BIOS image different than SCPH10000.BIN which is the oldest one
 	
 !!! info
-	Transfer your BIOS files to the retroarch/system/PCSX2/bios/ directory.
+	Transfer your BIOS files to the retroarch/system/pcsx2/bios/ directory.
 
 There is no region locking so if you have a PAL BIOS on your PS2 you can still play NTSC games, and vice versa. You'll also need the BIOS dumped from your PS2. Unlike the PS2 PCSX2 does not implement region locking so if you have a PAL BIOS in your PS2 you can still play NTSC games, and vice versa.
 
@@ -94,47 +94,41 @@ A PlayStation 2 BIOS consists of multiple files. All files of the same version (
 
 Currently, PCSX2 requires these directories in the folder set as frontend's System/BIOS directory:
 
-..\pcsx2\bios\
+.\pcsx2\bios\
 
-..\pcsx2\cheats\
+.\pcsx2\cheats\
 
-..\pcsx2\cheats_ws\
+.\pcsx2\cheats_ws\
 
-..\pcsx2\inis\
+.\pcsx2\inis\
 
-..\pcsx2\logs\
+.\pcsx2\logs\
 
-..\pcsx2\memcards\
+.\pcsx2\memcards\
 
-..\pcsx2\snaps\
+.\pcsx2\snaps\
 
-..\pcsx2\sstates\
+.\pcsx2\sstates\
 
 It also requires a file 'portable.ini' in the the \pcsx2\ directory in the frontend's System/BIOS directory. Simply create a portable.txt file and change its extension to .ini.
 
-- Linux version:
-
-Besides the files and folders above, currently, the Linux version of the PCSX2 core requires libpng12-0, which isn't available in the repositories of some distributions.
-
-One workaround that may help, if your distro supports PPAs, is using commands such as the following ones:
-
-> sudo add-apt-repository ppa:linuxuprising/libpng12
-> 
-> sudo apt update
-> 
-> sudo apt install libpng12-0
-
-Tested only in Ubuntu 20.04.2 LTS. May need to adapt to other distros.
-
 ## Extensions
 
-Content that can be loaded by the PCSX2 core have the following file extensions: elf|iso|ciso|cue|bin
+Content that can be loaded by the PCSX2 core have the following file extensions:
 
 - .elf
 - .iso
 - .ciso
+- .chd
+- .cso
 - .cue
 - .bin
+- .mdf
+- .nrg
+- .dump
+- .gz
+- .img
+- .m3u
 
 RetroArch database(s) that are associated with the PCSX2 core:
 
@@ -153,7 +147,7 @@ Frontend-level settings or features that the PCSX2 core respects.
 | Rewind            | ✕         |
 | Netplay           | ✕         |
 | Core Options      | ✔         |
-| [RetroAchievements](https://retroachievements.org/viewtopic.php?t=9302) | ✕         |
+| RetroAchievements | ✕         |
 | RetroArch Cheats  | ✕         |
 | Native Cheats     | ✔         |
 | Controls          | ✔         |
@@ -168,7 +162,7 @@ Frontend-level settings or features that the PCSX2 core respects.
 | Disk Control      | ✕         |
 | Username          | ✕         |
 | Language          | ✕         |
-| Crop Overscan[^2]   | ✕         |
+| Crop Overscan[^2] | ✕         |
 | LEDs              | ✕         |
 
 ### Directories

--- a/docs/library/yabause.md
+++ b/docs/library/yabause.md
@@ -58,7 +58,7 @@ Frontend-level settings or features that the Yabause core respects.
 | Rewind            | ✕         |
 | Netplay           | ✕         |
 | Core Options      | ✔         |
-| RetroAchievements | ✕         |
+| RetroAchievements | ✔         |
 | RetroArch Cheats  | ✔         |
 | Native Cheats     | ✕         |
 | Controls          | ✔         |


### PR DESCRIPTION
Regarding the PCSX2 doc, the libpng requirement for PCSX2 was mentioned on Discord a couple days ago as removed, hence removing that section. File extension updates were not personally validated, but were pulled from the core's info file.