### PR TITLE
Mention the PSP PSX BIOS support in the PS1 emulator pages

### DIFF
--- a/docs/library/beetle_psx.md
+++ b/docs/library/beetle_psx.md
@@ -28,11 +28,18 @@ A summary of the licenses behind RetroArch and its cores can be found [here](../
 
 Required or optional firmware files go in the frontend's system directory.
 
-|   Filename   | Description                         |              md5sum              |
-|:------------:|:-----------------------------------:|:--------------------------------:|
-| scph5500.bin | PS1 JP BIOS - Required for JP games | 8dd7d5296a650fac7319bce665a6a53c |
-| scph5501.bin | PS1 US BIOS - Required for US games | 490f666e1afb15b7362b406ed1cea246 |
-| scph5502.bin | PS1 EU BIOS - Required for EU games | 32736f17079d0b2b7024407c39bd3050 |
+|   Filename      | Description                           |              md5sum              |
+|:---------------:|:-------------------------------------:|:--------------------------------:|
+| scph5500.bin    | PS1 JP BIOS - Required for JP games   | 8dd7d5296a650fac7319bce665a6a53c |
+| scph5501.bin    | PS1 US BIOS - Required for US games   | 490f666e1afb15b7362b406ed1cea246 |
+| scph5502.bin    | PS1 EU BIOS - Required for EU games   | 32736f17079d0b2b7024407c39bd3050 |
+| PSXONPSP660.bin | PSP PS1 BIOS - Works with all regions | c53ca5908936d412331790f4426c6c33 |
+
+As a replacement for any of the BIOS files mentioned above, it is also possible
+to use the `PSXONPSP660.bin` BIOS. This BIOS comes from the PSP, is region-free
+and can sometimes offer better performance. For Beetle PSX to recognize this
+BIOS, it must be renamed to any of the names mentioned above (such as
+`scph5501.bin` for running US games).
 
 ## Extensions
 

--- a/docs/library/beetle_psx_hw.md
+++ b/docs/library/beetle_psx_hw.md
@@ -33,11 +33,18 @@ A summary of the licenses behind RetroArch and its cores can be found [here](../
 
 Required or optional firmware files go in the frontend's system directory.
 
-|   Filename   | Description                         |              md5sum              |
-|:------------:|:-----------------------------------:|:--------------------------------:|
-| scph5500.bin | PS1 JP BIOS - Required for JP games | 8dd7d5296a650fac7319bce665a6a53c |
-| scph5501.bin | PS1 US BIOS - Required for US games | 490f666e1afb15b7362b406ed1cea246 |
-| scph5502.bin | PS1 EU BIOS - Required for EU games | 32736f17079d0b2b7024407c39bd3050 |
+|   Filename      | Description                           |              md5sum              |
+|:---------------:|:-------------------------------------:|:--------------------------------:|
+| scph5500.bin    | PS1 JP BIOS - Required for JP games   | 8dd7d5296a650fac7319bce665a6a53c |
+| scph5501.bin    | PS1 US BIOS - Required for US games   | 490f666e1afb15b7362b406ed1cea246 |
+| scph5502.bin    | PS1 EU BIOS - Required for EU games   | 32736f17079d0b2b7024407c39bd3050 |
+| PSXONPSP660.bin | PSP PS1 BIOS - Works with all regions | c53ca5908936d412331790f4426c6c33 |
+
+As a replacement for any of the BIOS files mentioned above, it is also possible
+to use the `PSXONPSP660.bin` BIOS. This BIOS comes from the PSP, is region-free
+and can sometimes offer better performance. For Beetle PSX to recognize this
+BIOS, it must be renamed to any of the names mentioned above (such as
+`scph5501.bin` for running US games).
 
 ## Extensions
 

--- a/docs/library/pcsx_rearmed.md
+++ b/docs/library/pcsx_rearmed.md
@@ -23,16 +23,21 @@ Required or optional firmware files go in the frontend's system directory.
 !!! attention
 	In case the PCSX ReARMed core can find no BIOS files named like this in RetroArch's system directory, it will default to a High-Level Emulation BIOS. This decreases the level of compatibility of the emulator, so it is recommended that you always supply valid BIOS images inside the system directory.
 
-|   Filename    |      Description       |              md5sum              |
-|:-------------:|:----------------------:|:--------------------------------:|
-| scph101.bin   | Version 4.4 03/24/00 A | 6E3735FF4C7DC899EE98981385F6F3D0 |
-| scph7001.bin  | Version 4.1 12/16/97 A | 1e68c231d0896b7eadcad1d7d8e76129 |
-| scph5501.bin  | Version 3.0 11/18/96 A | 490f666e1afb15b7362b406ed1cea246 |
-| scph1001.bin  | Version 2.0 05/07/95 A | 924e392ed05558ffdb115408c263dccf |
+|   Filename      |      Description       |              md5sum              |
+|:---------------:|:----------------------:|:--------------------------------:|
+| scph101.bin     | Version 4.4 03/24/00 A | 6E3735FF4C7DC899EE98981385F6F3D0 |
+| scph7001.bin    | Version 4.1 12/16/97 A | 1e68c231d0896b7eadcad1d7d8e76129 |
+| scph5501.bin    | Version 3.0 11/18/96 A | 490f666e1afb15b7362b406ed1cea246 |
+| scph1001.bin    | Version 2.0 05/07/95 A | 924e392ed05558ffdb115408c263dccf |
+| PSXONPSP660.bin | Extracted from a PSP   | c53ca5908936d412331790f4426c6c33 |
 
-In the event that none of the above is found, PCSX_ReARMed will search for filenames starting with "scph" and use that instead.
-It doesnt seem to matter whatever bios version is used and from what region as long as its from a retail psx/ps-one.
-If no compatible bios is found, PCSX_ReARMed will revert to use HLE bios, which can have compatibility issues (e.g. memcard issues in Suikoden games and some games just going into black screens...)
+As a replacement for any of the first 3 BIOS files mentioned above, it is also possible
+to use the `PSXONPSP660.bin` BIOS. This BIOS comes from the PSP, is region-free
+and can sometimes offer better performance.
+
+If none of the above is found, PCSX_ReARMed will search for filenames starting with "scph" and use that instead.
+It doesn't seem to matter whatever BIOS version is used and from what region, as long as it's from a retail PSX/PS one.
+If no compatible BIOS is found, PCSX_ReARMed will revert to use the HLE BIOS, which can have compatibility issues (e.g. memory card issues in Suikoden games, some games just going into black screens, ...).
 
 ## Extensions
 


### PR DESCRIPTION
This BIOS is region-free and can provide better performance, which makes it a worthwhile option in many cases.

See https://github.com/libretro/pcsx_rearmed/pull/339 and https://github.com/libretro/beetle-psx-libretro/issues/519.