### PR TITLE
add to source abbreviations in coding standards

### DIFF
--- a/docs/development/coding-standards.md
+++ b/docs/development/coding-standards.md
@@ -117,9 +117,16 @@ typedef struct input_driver_state
 | Abbreviation  | Meaning        |
 | ------------- | -------------- |
 | ra, rarch     | RetroArch      |
+| av            | Audio-Visual   |
+| cb            | Callback       |
 | ctx           | Context        |
+| gfx           | Graphics       |
+| hw            | Hardware       |
 | idx           | Index          |
 | ptr           | Pointer        |
+| st            | State          |
+| sw            | Software       |
+| ui            | User interface |
 
 
 ### vim configuration for Libretro style


### PR DESCRIPTION
These are all pretty common as I continue to look though RA code. I am not adding abbreviations that are unique or rare.