### PR TITLE
Update Beetle PSX HW and non-HW BIOS section

### DIFF
--- a/docs/library/beetle_psx.md
+++ b/docs/library/beetle_psx.md
@@ -33,15 +33,14 @@ Required or optional firmware files go in the frontend's system directory.
 | scph5500.bin    | PS1 JP BIOS - Required for JP games   | 8dd7d5296a650fac7319bce665a6a53c |
 | scph5501.bin    | PS1 US BIOS - Required for US games   | 490f666e1afb15b7362b406ed1cea246 |
 | scph5502.bin    | PS1 EU BIOS - Required for EU games   | 32736f17079d0b2b7024407c39bd3050 |
-| PSXONPSP660.bin | PSP PS1 BIOS - Works with all regions | c53ca5908936d412331790f4426c6c33 |
-| ps1_rom.bin     | PS3 PS1 BIOS - Works with all regions | 81bbe60ba7a3d1cea1d48c14cbcc647b |
 
-As a replacement for any of the BIOS files mentioned above, it is also possible
-to use either the `PSXONPSP660.bin` or `ps1_rom.bin` BIOS.  The `PSXONPSP660.bin` BIOS
-comes from the PSP, and the `ps1_rom.bin` BIOS comes from the PS3, both are region-free
-and can sometimes offer better performance. For Beetle PSX to recognize either of these
-BIOS, it must be renamed to any of the first three names mentioned in the table above
-(such as `scph5501.bin` for running US games).
+As a replacement for any of the BIOS files mentioned above, it is also possible to use either of these BIOSes:
+
+- `PSXONPSP660.bin` (MD5: c53ca5908936d412331790f4426c6c33)
+- `ps1_rom.bin` (MD5: 81bbe60ba7a3d1cea1d48c14cbcc647b)
+
+The `PSXONPSP660.bin` BIOS comes from the PSP, and the `ps1_rom.bin` BIOS comes from the PS3, both are region-free.
+For Beetle PSX to recognize either of these BIOSes, it must be renamed to any of the first three names mentioned in the table above (such as `scph5501.bin` for running US games).
 
 ## Extensions
 

--- a/docs/library/beetle_psx_hw.md
+++ b/docs/library/beetle_psx_hw.md
@@ -38,15 +38,14 @@ Required or optional firmware files go in the frontend's system directory.
 | scph5500.bin    | PS1 JP BIOS - Required for JP games   | 8dd7d5296a650fac7319bce665a6a53c |
 | scph5501.bin    | PS1 US BIOS - Required for US games   | 490f666e1afb15b7362b406ed1cea246 |
 | scph5502.bin    | PS1 EU BIOS - Required for EU games   | 32736f17079d0b2b7024407c39bd3050 |
-| PSXONPSP660.bin | PSP PS1 BIOS - Works with all regions | c53ca5908936d412331790f4426c6c33 |
-| ps1_rom.bin     | PS3 PS1 BIOS - Works with all regions | 81bbe60ba7a3d1cea1d48c14cbcc647b |
 
-As a replacement for any of the BIOS files mentioned above, it is also possible
-to use either the `PSXONPSP660.bin` or `ps1_rom.bin` BIOS.  The `PSXONPSP660.bin` BIOS
-comes from the PSP, and the `ps1_rom.bin` BIOS comes from the PS3, both are region-free
-and can sometimes offer better performance. For Beetle PSX HW to recognize either of
-these BIOS, it must be renamed to any of the first three names mentioned in the table
-above (such as `scph5501.bin` for running US games).
+As a replacement for any of the BIOS files mentioned above, it is also possible to use either of these BIOSes:
+
+- `PSXONPSP660.bin` (MD5: c53ca5908936d412331790f4426c6c33)
+- `ps1_rom.bin` (MD5: 81bbe60ba7a3d1cea1d48c14cbcc647b)
+
+The `PSXONPSP660.bin` BIOS comes from the PSP, and the `ps1_rom.bin` BIOS comes from the PS3, both are region-free.
+For Beetle PSX HW to recognize either of these BIOSes, it must be renamed to any of the first three names mentioned in the table above (such as `scph5501.bin` for running US games).
 
 ## Extensions
 


### PR DESCRIPTION
The 2 alternatives BIOSes shouldn't be in the table, since you can't put them in your system folder directly without renaming this is kinda misleading, especially if someone doesn't read the text below.

Also removed the "and can sometimes offer better performance" comment, as I don't think there was ever any proof of that.