### PR TITLE
Fix Gearboy repo urls

### DIFF
--- a/docs/development/licenses.md
+++ b/docs/development/licenses.md
@@ -116,7 +116,7 @@ See below for a summary of the licenses behind RetroArch and its cores:
 | Fuse                                                                             | [GPLv3](https://github.com/libretro/fuse-libretro/blob/master/LICENSE)                    |                |
 | [Gambatte](../library/gambatte.md)                                               | [GPLv2](https://github.com/libretro/gambatte-libretro/blob/master/COPYING)                |                |
 | [Game Music Emu](../library/game_music_emu.md)            		           | [GPLv3](https://github.com/libretro/libretro-gme/blob/master/LICENSE)                     |                |
-| [Gearboy](../library/gearboy.md)                                                 | [GPLv3](https://github.com/libretro/Gearboy/blob/master/LICENSE)                          |                |
+| [Gearboy](../library/gearboy.md)                                                 | [GPLv3](https://github.com/drhelius/Gearboy/blob/master/LICENSE)                          |                |
 | [Gearsystem](../library/gearsystem.md)                                           | [GPLv3](https://github.com/drhelius/Gearsystem/blob/master/LICENSE)                       |                |
 | [Genesis Plus GX](../library/genesis_plus_gx.md)          		           | [Non-commercial](https://github.com/libretro/Genesis-Plus-GX/blob/master/LICENSE.txt)     | Non-commercial |
 | [gpSP](../library/gpsp.md)                                                       | [GPLv2](https://github.com/libretro/gpsp/blob/master/COPYING)                             |                |

--- a/docs/guides/retroachievements.md
+++ b/docs/guides/retroachievements.md
@@ -175,7 +175,7 @@ You can also check the progress of your friends and add comments on their trophi
 |-----------------------------------------------------------|:---------:|:------|
 | [Gambatte](https://github.com/libretro/gambatte-libretro) | ✔         |       |
 | [SameBoy](https://github.com/libretro/SameBoy)            | ✔         | Highest accuracy, may have issues with some achievement sets for the time being |
-| [Gearboy](https://github.com/libretro/gearboy)            | ✔         |       |
+| [Gearboy](https://github.com/drhelius/Gearboy)            | ✔         |       |
 | [VBA-M](https://github.com/libretro/vbam-libretro)        | ✔         | Has gyro support via analog sticks |
 | [mGBA](https://github.com/libretro/mgba)                  | ✔         |       |
 | [Mesen-S](https://github.com/SourMesen/Mesen-S)           | ✔         | Currently the only supported core with complete SGB support. Supports GB and GBC without SGB as well. |

--- a/docs/library/gearboy.md
+++ b/docs/library/gearboy.md
@@ -21,7 +21,7 @@ The Gearboy core has been authored by:
 
 The Gearboy core is licensed under:
 
-- [GPLv3](https://github.com/libretro/Gearboy/blob/master/LICENSE)
+- [GPLv3](https://github.com/drhelius/Gearboy/blob/master/LICENSE)
 
 A summary of the licenses behind RetroArch and its cores can be found [here](../development/licenses.md).
 
@@ -186,7 +186,6 @@ Settings with (Restart) means that core has to be closed for the new setting to 
 
 - [Official Gearboy Github Repository](https://github.com/drhelius/Gearboy)
 - [Libretro Gearboy Core info file](https://github.com/libretro/libretro-super/blob/master/dist/info/gearboy_libretro.info)
-- [Libretro Gearboy Github Repository](https://github.com/libretro/Gearboy)
 - [Report Libretro Gearboy Core Issues Here](https://github.com/drhelius/Gearboy/issues)
 
 ### See also


### PR DESCRIPTION
RA uses Gearboy upstream repo. This fixes some old urls that may generate confusion in some users.