### PR TITLE
Rewrite 'Adding new languages to RetroArch'

### DIFF
--- a/docs/development/retroarch/new-translations-crowdin.md
+++ b/docs/development/retroarch/new-translations-crowdin.md
@@ -2,9 +2,9 @@
 
 <iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/V-j08aSegHM" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
-As libretro, it is very important for us that RetroArch can be easily understood by everyone. Making multiple languages available in RetroArch will ensure a better understanding of the options and a better experience for more people. Currently, RetroArch is in the process of being translated into 33 languages. In the pursuit of streamlining the process and making it more accessible for new contributors we decided to utilise the crowdsourced translation service **Crowdin**[^1].
+As libretro, it is very important for us that RetroArch can be easily understood by everyone. Making multiple languages available in RetroArch will ensure a better understanding of the options and a better experience for more people. Currently, RetroArch is in the process of being translated into over 35 languages. In the pursuit of streamlining the process and making it more accessible for new contributors we decided to utilise the crowdsourced translation service **Crowdin**[^1].
 
-[^1]: RetroArch and libretro are not affiliated in any way with Crowdin.
+[^1]: https://crowdin.com/ - RetroArch and libretro are not affiliated in any way with Crowdin.
 
 ## What is Crowdin?
 
@@ -42,7 +42,9 @@ You can add translations and suggestions to the project regardless of whether yo
 
 ### How to translate strings
 
-After selecting the language you want to translate to, you will be welcomed by the file selection page. At the moment the most important files are _msg\_hash\_us.json_, which contains the (options) texts of the RetroArch program, as well as _googleplay\_us.json_ and _steam\_us.json_, which contain RetroArch’s Google Store and Steam page descriptions, respectively.
+After selecting the language you want to translate to (you may request additional languages at the `#retroarch-translations` channel of our Discord[^2]), you will be welcomed by the file selection page. At the moment the most important files are _msg\_hash\_us.json_, which contains the (options) texts of the RetroArch program, as well as _googleplay\_us.json_ and _steam\_us.json_, which contain RetroArch’s Google Store and Steam page descriptions, respectively.
+
+[^2]: The official RetroArch Discord server: https://discord.gg/2E8pNrCR
 
 <figure markdown>
    <center>
@@ -121,11 +123,16 @@ Voting is very simple:  At the bottom half of the middle section of the translat
 
 But even with a voting system in place, at some point we would probably want to just decide on an official translation, which will be chosen regardless of the votes. That’s where proofreaders come into play.
 
-First things first: **in order to become a proofreader, translators will need additional authorization by RetroArch’s translation managers.** We suggest you contact us at the _#retroarch-translations_ channel, located in RetroArch’s Discord server, in order to discuss this authorization.
+First things first: **in order to become a proofreader, translators will need additional authorization by RetroArch’s translation managers.** We suggest you contact us at the `#retroarch-translations` channel, located in RetroArch’s Discord server[^2], in order to discuss this authorization.
 
 As a proofreader, you don’t get to vote on the translations any more. Instead, if you find a translation to be suitable and free of errors you can click on the ![Approve button](../../image/development/crowdin-approve-button.png) button to _approve_ it. Approving a translation makes it the ‘default’ and elevates it above all others. Only one translation can be approved at a time for each source string and language. Translators can still vote on it, though, and it would be wise to rethink one's choice if the votes demand it.
 
 In addition to approving translations, proofreaders also may delete _any_ suggested translation, not just their own. It should be easy to see why additional authorization is needed for this position.
+
+### Seeing results in the app
+
+For languages already included in RetroArch the translations are updated daily for the main app and weekly every Friday for cores.
+Other languages will need to be incorporated into the code of RetroArch and the cores. Once at least 15% of the `msg_hash_us.h` file is translated, the Crowdin managers will start work on including this language in the app. If you'd like to take matters in your own hands, you can find instructions [here](new-translations.md).
 
 ## Advanced Instructions
 
@@ -154,7 +161,7 @@ Since RetroArch and libretro are C/C++ projects, the strings will sometimes cont
    </figcaption>
 </figure>
 
-This is not a complete list — there are quite a few more. But don't worry: in Crowdin these special elements are marked accordingly, and you will receive reminders should you forget to use them in your translations. And always remember: if there is something unclear about a source text, just ask about it in a comment on Crowdin or on Discord!
+This is not a complete list — there are quite a few more. But don't worry: in Crowdin these special elements are marked accordingly, and you will receive reminders should you forget to use them in your translations. And always remember: if there is something unclear about a source text, just ask about it in a comment on Crowdin or on Discord[^2]!
 
 <figure markdown>
    <center>
@@ -191,7 +198,7 @@ The best way to check for other translations, without having to leave the curren
 
 In the ‘Source String’ area you’ll find some words that are underlined. These are words that contain references to existing translations. Hover your mouse over these words to see the current translation references. As of the writing of this document, there are two types of references:
 
-- **Glossary terms**: These terms have been selected/translated by other members of the translation team (or other language teams, depending on the case) and should be used as much as possible. If you'd like to change an existing glossary term translation, please talk about it with any active translators of your language first. If your language currently does not have translators, but its progress is very high, do not change the existing terms on your own. Please contact other people on e.g. Discord and try to reach a consensus.
+- **Glossary terms**: These terms have been selected/translated by other members of the translation team (or other language teams, depending on the case) and should be used as much as possible. If you'd like to change an existing glossary term translation, please talk about it with any active translators of your language first. If your language currently does not have translators, but its progress is very high, do not change the existing terms on your own. Please contact other people on e.g. Discord[^2] and try to reach a consensus.
 - **Previous translations**: Crowdin will routinely check for repeated words and show what it thinks is a good translation based on previous input. These suggestions are marked with "Previously translated as:". This system is not perfect and should not be entirely trusted.
 
 <figure markdown>

--- a/docs/development/retroarch/new-translations.md
+++ b/docs/development/retroarch/new-translations.md
@@ -1,125 +1,152 @@
-# Adding a new language to RetroArch
+# Adding new languages to RetroArch
+
+While translation is handled via the Crowdin[^1] platform ([more here](new-translations-crowdin.md)), RetroArch's code must be adjusted for it to display new languages.
 
 ## Files to change
 
-* `libretro-common/include/libretro.h`
-* `msg_hash.h`
-* `msg_hash.c`
 * `Makefile.common`
+* `msg_hash.c`
+* `msg_hash.h`
+* `retroarch.c`
+* `griffin/griffin.c`
 * `intl/msg_hash_xx.c` (new file)
-* `intl/msg_hash_xx.h` (new file)
 * `intl/msg_hash_us.h`
 * `menu/menu_setting.c`
-* `griffin/griffin.c`
-* `retroarch.c`
+* `libretro-common/include/libretro.h`
 
-## Instructions
+> Every new language must first be added to the project on Crowdin. This will ensure that a corresponding `intl/msg_hash_xx.h` file is created. Requests are accepted at the `#retroarch-translations` channel of the RetroArch Discord[^2].
 
-1. Open `libretro-common/include/libretro.h`
-2. Add a `RETRO_LANGUAGE_XXXXX` item to the `retro_language` enum just above `RETRO_LANGUAGE_LAST`, using the next available integer value
-3. Open `msg_hash.h`
-4. Add a `MENU_ENUM_LABEL_VALUE_LANG_XXXXX` item to the `msg_hash_enums` enum
-5. Add declaration of a `const char *msg_hash_to_str_xx(enum msg_hash_enums msg)` function
-6. Add declaration of a `int menu_hash_get_help_xx_enum(enum msg_hash_enums msg, char *s, size_t len)` function
-7. Open `msg_hash.c`
-8. Add a
-     ```c
-     case RETRO_LANGUAGE_XXXXX:
-         ret = menu_hash_get_help_xx_enum(msg, s, len);
-         break;
-     ```
-   block inside the `menu_hash_get_help_enum()` function
-9. Add a
-     ```c
-     case RETRO_LANGUAGE_XXXXX:
-         ret = msg_hash_to_str_xx(msg);
-         break;
-     ```
-   block inside the `msg_hash_to_str()` function
-10. Open `Makefile.common`
-11. Add `intl/msg_hash_xx.o` to `OBJS`
-12. Copy `intl/msg_hash_us.c` to `intl/msg_hash_xx.c`
-13. Decide if `intl/msg_hash_xx.c` should use UTF-8 + BOM encoding. See the section below
-14. Open `intl/msg_hash_xx.c`
-15. Rename the `menu_hash_get_help_us_enum()` function to `menu_hash_get_help_xx_enum()`
-16. Rename the `menu_hash_to_str_us_label_enum()` function to `menu_hash_to_str_xx_label_enum()`
-17. Rename the `menu_hash_to_str_us()` function to `msg_hash_to_str_xx()` and, inside that same function:
-    * Replace the call to `menu_hash_to_str_us_label_enum()` with a call to `menu_hash_to_str_xx_label_enum()`
-    * Replace the `#include "msg_hash_us.h"` line with #include "msg_hash_xx.h"
-18. Open `intl/msg_hash_us.h`
-19. Add a
-     ```c
-     MSG_HASH(MENU_ENUM_LABEL_VALUE_LANG_XXXXX, "Xxxxx")
-     ```
-    block with the name of the new language written in English
-20. Copy `intl/msg_hash_us.h` to `intl/msg_hash_xx.h`
-21. Decide if `intl/msg_hash_xx.h` should use UTF-8 + BOM encoding. See the section below
-22. Open `intl/msg_hash_xx.h`
-23. Make sure to modify the
-     ```c
-     MSG_HASH(MENU_ENUM_LABEL_VALUE_LANG_XXXXX, "Xxxxx")
-     ```
-    block to show the name of the new language written *in* the target language
-24. Open `menu/menu_setting.c`
-25. Add a
-     ```c
-     modes[RETRO_LANGUAGE_XXXXX] = msg_hash_to_str(MENU_ENUM_LABEL_VALUE_LANG_XXXXX);
-     ```
-    assignment to the `setting_get_string_representation_uint_user_language()` function
-26. Open `griffin/griffin.c`
-27. Add a `#include "../intl/msg_hash_xx.c"` line below the existing, similar
-    ones for other languages.
-28. Open `retroarch.c`
-29. Add you language for the first startup in `enum retro_language rarch_get_language_from_iso(const char *iso639)`
-     ```c
-     {"XX", RETRO_LANGUAGE_XXXXX},
-     ```
+[^1]: https://crowdin.com/ - RetroArch and libretro are not affiliated in any way with Crowdin.
+[^2]: The official RetroArch Discord server: https://discord.gg/2E8pNrCR
 
-### Encoding of translation files
+## Main Instructions
 
-* Translation files (`intl/msg_hash_xx.{c,h}`) in general must be UTF-8 encoded
-* For some languages, these files need to have a "UTF-8 Unicode (with BOM)"
-  encoding, this is, UTF-8 and a
-  [BOM](https://en.wikipedia.org/wiki/Byte_order_mark). AFAIK this is so
-  because a requirement of the MSVC compilers (Windows platform). Examples of
-  this as of now are:
+To add a language with the English name `XXXXX` and two-letter code `xx` follow these steps:
 
-    * `msg_hash_ar.{c,h}`
-    * `msg_hash_chs.{c,h}`
-    * `msg_hash_cht.{c,h}`
-    * `msg_hash_ja.{c,h}`
-    * `msg_hash_ko.{c,h}`
-    * `msg_hash_pl.{c,h}`
-    * `msg_hash_ru.{c,h}`
-    * `msg_hash_vn.h`
+1. Open `libretro-common/include/libretro.h`.
+    1. Add a `RETRO_LANGUAGE_XXXXX` item to the `retro_language` enum just above `RETRO_LANGUAGE_LAST`, using the next available integer value.
+> Do not rearrange the elements of this list! This would break the language association for the cores!
+2. Open `msg_hash.h`.
+    1. Check if a `MENU_ENUM_LABEL_VALUE_LANG_XXXXX` item for your language is present in the `msg_hash_enums` enum; if not, add it.
+    2. Add declaration of a `const char *msg_hash_to_str_xx(enum msg_hash_enums msg)` function.
+    3. Add declaration of a `int msg_hash_get_help_xx_enum(enum msg_hash_enums msg, char *s, size_t len)` function.
+3. Open `msg_hash.c`.
+    1. Add the following block inside the `msg_hash_get_help_enum(enum msg_hash_enums msg, char *s, size_t len)` function:
+```c
+case RETRO_LANGUAGE_XXXXX:
+   ret = msg_hash_get_help_xx_enum(msg, s, len);
+   break;
+```
+    2. Add the following block inside the `get_user_language_iso639_1(bool limit)` function:
+```c
+case RETRO_LANGUAGE_XXXXX:
+   return "xx";
+```
+    3. Add the following block inside the `msg_hash_to_str(enum msg_hash_enums msg)` function:
+```c
+case RETRO_LANGUAGE_XXXXX:
+    ret = msg_hash_to_str_xx(msg);
+    break;
+```
+4. Open `Makefile.common`.
+    1. Add `intl/msg_hash_xx.o` to `OBJ`.
+5. Create a copy of `intl/msg_hash_us.c` and name it `intl/msg_hash_xx.c`.
+6. Decide if `intl/msg_hash_xx.c` and `intl/msg_hash_xx.h` should use UTF-8 + BOM encoding. See the section below.
+7. Open `intl/msg_hash_xx.c`.
+    1. Rename the `msg_hash_get_help_us_enum()` function to `msg_hash_get_help_xx_enum()`.
+    2. Rename the `menu_hash_to_str_us_label_enum()` function to `menu_hash_to_str_xx_label_enum()`.
+    3. Rename the `msg_hash_to_str_us()` function to `msg_hash_to_str_xx()` and, inside that same function:
+       * Replace the call to `menu_hash_to_str_us_label_enum()` with a call to `menu_hash_to_str_xx_label_enum()`.
+       * Replace the `#include "msg_hash_us.h"` line with `#include "msg_hash_xx.h"`.
+8. Open `intl/msg_hash_us.h`.
+    1. Check if the following block is present, where `Yyyyy` is the native name of the language and if not, add it:
+```c
+MSG_HASH(
+   MENU_ENUM_LABEL_VALUE_LANG_XXXXX,
+   "Xxxxx - Yyyyy"
+   )
+```
+9. Open `menu/menu_setting.c`.
+    1. Add the following assignment to the `setting_get_string_representation_uint_user_language()` function:
+```c
+modes[RETRO_LANGUAGE_XXXXX] = msg_hash_to_str(MENU_ENUM_LABEL_VALUE_LANG_XXXXX);
+```
+10. Open `griffin/griffin.c`.
+    1. Add the line `#include "../intl/msg_hash_xx.c"` below the existing, similar ones for other languages.
+11. Open `retroarch.c`.
+    1. Add your language to `enum retro_language rarch_get_language_from_iso(const char *iso639)`:
+```c
+{"xx", RETRO_LANGUAGE_XXXXX},
+```
 
-* Be careful when creating and editing your new translation files as some text
-  editors do strip the BOM without warning.
+## Optional Adjustments
 
-### Example: Addition of Arabic language:
+### RGUI Compatibility
 
-* Commit [45580cb](https://github.com/libretro/RetroArch/commit/45580cb9a8f0fcd0a87f00eadf26d87f05289485)
-* Commit [d8f1a08](https://github.com/libretro/RetroArch/commit/d8f1a08a4758851d5530d311303146257cbf8216)
-* Commit [7a0428f](https://github.com/libretro/RetroArch/commit/7a0428fc769fd0eca663207134bec311aa3e30f3)
+To make the new language usable with the RGUI menu driver:
 
-### Translation
+1. Open `menu/drivers/rgui.c`.
+2. Navigate to the `rgui_fonts_init(rgui_t *rgui)` function.
+3. Add `case RETRO_LANGUAGE_XXXXX:` to
+    1. the extended ASCII section if the new language uses the Latin alphabet (+ some extra chars), or
+    2. any other present language the new language shares the alphabet with (like Russian).
+4. If a new language was added, it is important to compile RetroArch with the changes and ensure the new language works correctly with RGUI.
+5. If your language uses a different range of symbols, an RGUI compatible font must be added first. This is an extensive process, which is outside the scope of this article.
 
-If you speak the target language xx then you could start translating literals in
+### Enabling new languages in cores
 
-* `intl/msg_hash_xx.c`
+Adding a language to RetroArch does not automatically enable it for the core options.
+To do that for cores which have been added to Crowdin, follow these steps:
 
-by replacing the English original one with its translations.
+1. Locate the `libretro.h` file and add a `RETRO_LANGUAGE_XXXXX` item to the `retro_language` enum exactly the same as was done for RetroArch.
+    1. Alternatively, overwrite this file with the `libretro-common/include/libretro.h` file from RetroArch's code.
+2. Locate the `libretro_core_options.h` file and open it.
+    1. Add `&options_xx,` at the end of the `retro_core_options_v2` struct. Remember to keep the same order as in the `retro_language` enum.
 
-The main file for RetroArch is located here:
+## Encoding of translation files
 
-* `intl/msg_hash_xx.h`
+Translation files (`intl/msg_hash_xx.{c,h}`) in general must be UTF-8 encoded.
+For some languages, these files need to have a "UTF-8 Unicode (with [BOM](https://en.wikipedia.org/wiki/Byte_order_mark))" encoding. AFAIK, this is because of a requirement of the MSVC compilers for the Windows platform. Examples of this as of now are:
 
-But .h files are periodically updated and overwritten by the Crowdin translations website 
-([Link here](https://crowdin.com/project/retroarch), so it's best to do any changes to 
-non-English languages there. If you want to know more, go to the 
-([Helping with RetroArch translations](https://docs.libretro.com/development/retroarch/new-translations-crowdin/)
-doc.
+* `msg_hash_ar.{c,h}`
+* `msg_hash_chs.{c,h}`
+* `msg_hash_cht.{c,h}`
+* `msg_hash_ja.{c,h}`
+* `msg_hash_ko.{c,h}`
+* `msg_hash_pl.{c,h}`
+* `msg_hash_ru.{c,h}`
+* `msg_hash_vn.h`
+
+Be careful when creating and editing your new translation files, as some text editors do strip the BOM without warning.
+
+## Examples
+
+### Adding languages to RetroArch
+
+* Arabic:
+    * [add basic support for arabic.](https://github.com/libretro/RetroArch/commit/45580cb9a8f0fcd0a87f00eadf26d87f05289485)
+    * [add byte-order-marker to msg_hash_ar.*](https://github.com/libretro/RetroArch/commit/d8f1a08a4758851d5530d311303146257cbf8216)
+    * [Add "Arabic" to intl/msg_hash_us.h missed in 45580cb.](https://github.com/libretro/RetroArch/commit/7a0428fc769fd0eca663207134bec311aa3e30f3)
+
+* Indonesian, Swedish and Ukrainian (+RGUI):
+    * [Add Indonesian, Swedish and Ukrainian language options](https://github.com/libretro/RetroArch/commit/311fec15d9db10ab14c879e898a8205dd37f827c)
+
+### Enabling new languages for cores
+
+* mgba:
+    * [Enable Indonesian, Swedish and Ukrainian localisations](https://github.com/libretro/mgba/commit/b0cdccc9ad2e5a8cd40ad4b9a3db1587d6f1560b)
+
+## Translation
+
+If you speak the target language `xx` then you could start translating on Crowdin.
+Instructions and recommended reading for that can be found [here](https://docs.libretro.com/development/retroarch/new-translations-crowdin/).
+
+> Please **do not change** the `intl/msg_hash_xx.h` files directly!
+
+The `intl/msg_hash_xx.c` files are not yet included on Crowdin, but that's because an overhaul of these files is currently a work-in-progress. If you just can't wait any longer, you can start translating those files by replacing the English texts with the respective translations.
+We will try to preserve your efforts.
 
 ## See also
 
 * [Adding a RetroArch menu option](new-menu-options.md)
+* [Helping with RetroArch translations](new-translations-crowdin.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -314,7 +314,7 @@ nav:
         - 'Input Driver Specification': 'development/retroarch/input/input-drivers.md'
         - 'Input Overlays': 'development/retroarch/input/overlay.md'
         - 'Parallel Port Controllers': 'development/retroarch/input/parallel-port-controllers.md'
-      - 'Adding New Languages or New Strings': 'development/retroarch/new-translations.md'
+      - 'Adding new languages to RetroArch': 'development/retroarch/new-translations.md'
       - 'Helping with RetroArch translations': 'development/retroarch/new-translations-crowdin.md'
       - 'Network Protocols':
         - 'Netplay': 'development/retroarch/netplay.md'


### PR DESCRIPTION
## Description

The old article describing how to add new languages to RetroArch was no longer accurate - so I updated it with references to the Crowdin translation guide and a few new example commits.

Also added some links to the mentioned translation guide.

## Reviewers
@guoyunhe
@IlDucci 