### PR TITLE
.chd support has been added to lr-picodrive

### DIFF
--- a/docs/library/picodrive.md
+++ b/docs/library/picodrive.md
@@ -43,6 +43,7 @@ Content that can be loaded by the PicoDrive core have the following file extensi
 - .iso
 - .sms
 - .68k
+- .chd
 
 RetroArch database(s) that are associated with the PicoDrive core:
 


### PR DESCRIPTION
I just verified that libretro/picodrive#194 successfully adds .chd support to Picodrive. The latest stable release of lr-picodrive (on Linux, 64-bit) runs the rom file Slam City with Scottie Pippen (USA) (Disc 1) (Fingers) (Sega CD 32X).chd perfectly.