### PR TITLE
PUAE updates + PCSX2 markdown fix

### DIFF
--- a/docs/library/pcsx2.md
+++ b/docs/library/pcsx2.md
@@ -28,23 +28,23 @@ A summary of the licenses behind RetroArch and its cores can be found [here](../
 
 ## Requirements
 
-=== "CPU"
+CPU
 
-    * Supports SSE2/AVX2
-    * PassMark Single Thread Performance rating near or greater than 1600/2100
-    * Two physical cores, with hyperthreading
-    * Four physical cores, with or without hyperthreading
+- Supports SSE2/AVX2
+- PassMark Single Thread Performance rating near or greater than 1600/2100
+- Two physical cores, with hyperthreading
+- Four physical cores, with or without hyperthreading
 
-=== "GPU"
+GPU
 
-	* Direct3D10/11 support
-	* OpenGL 3.x/4.5 support
-	* PassMark G3D Mark rating around 3000 (GeForce GTX 750)
-	* 2 GB/4 GB Video Memory
+- Direct3D10/11 support
+- OpenGL 3.x/4.5 support
+- PassMark G3D Mark rating around 3000 (GeForce GTX 750)
+- 2 GB/4 GB Video Memory
 
-=== "RAM"
+RAM
 
-	* 4GB/8GB
+- 4GB/8GB
 
 !!! Attention
 	Because of the complex nature of emulation, even if you meet the recommended requirements there will be games that will NOT run at full speed due to emulation imperfection, floating point emulation differences, issues with emulator itself or other problems.

--- a/docs/library/puae.md
+++ b/docs/library/puae.md
@@ -174,6 +174,8 @@ When the game asks for it, you can change the current disk in the RetroArch "Dis
 
 For games that support multiple disk drives, append "**(MD)**" as in "MultiDrive" to the M3U filename to insert each disk in different drives. Only possible with maximum 4 disks!
 
+***MultiDrive option is enabled by default, so the tag is not necessary, but some games require disabling it, because they can't handle multiple disk drives.***
+
 For games that require a dedicated save disk, one may be generated automatically by entering the following line in an M3U file: `#SAVEDISK:VolumeName`. `VolumeName` is optional and may be omitted. For example, this will create a blank, unlabelled disk image at disk index 5:
 
 `Secret of Monkey Island.m3u`
@@ -467,7 +469,7 @@ Settings with (Restart) means that core has to be closed for the new setting to 
 
     Default model when floppies are launched with 'Automatic' model. Core restart required.
 
-- **Automatic HD** [puae_model_hd] (**A600**|A1200OG|A1200|A2000|A4030|A4040)
+- **Automatic HD** [puae_model_hd] (A600|A1200OG|**A1200**|A2000|A4030|A4040)
 
     Default model when HD interface is used with 'Automatic' model. Affects WHDLoad installs and other hard drive images. Core restart required.
 
@@ -479,7 +481,7 @@ Settings with (Restart) means that core has to be closed for the new setting to 
 
     'Automatic' defaults to the most compatible version for the model. 'AROS' is a built-in replacement with fair compatibility. Core restart required.
 
-- **CPU Compatibility** [puae_cpu_compatibility] (normal|**compatible**|exact)
+- **CPU Compatibility** [puae_cpu_compatibility] (normal|**compatible**|memory|exact)
 
     Some games have graphic and/or speed issues without 'Cycle-exact'. 'Cycle-exact' can be forced with '(CE)' file path tag.
 


### PR DESCRIPTION
Updated PUAE to match current state and removed `===` from PCSX2 because they will break the sidebar menu.
