### PR TITLE
New readme for DOSBox Pure

### DIFF
--- a/docs/library/dosbox-pure.md
+++ b/docs/library/dosbox-pure.md
@@ -95,11 +95,9 @@ For details how to use it and how to find new cheats while playing the game, che
 
 The DOSBox Pure core fully supports libretro save states. Make sure to test it in each game before using it. Complex late era DOS games might have problems.
 
-Be aware that states saved with different video or cpu settings are not loadable.
+Be aware that states saved with different video or cpu settings are not loadable. Also, save states might not be compatible across different versions of DOSBox Pure.
 
-Save states might not be compatible across different versions of DOSBox Pure.
-
-Rewind support
+### Rewind support
 
 Using the core option `Save States Support`, rewinding can be enabled. Keep in mind that rewind support comes at a high performance cost.
 
@@ -226,13 +224,9 @@ This index buffer should be stored into the game save file to avoid having to sl
 
 For now, serial port and IPX emulation from base DOSBox have been removed.
 
-!!! tip
-    **Thoughts by Matt** I seem to remember this core looks up games in an extensive online database of DOS games, so it enables RetroArch to easily create playlists from a user's collection of DOS games? In general, it might be useful to have a section about creating playlists here, I'll be happy to write it but I need to understand it better myself first.
-
 ## Core options
-![#f03c15](https://via.placeholder.com/15/f03c15/000000?text=+) (Still need to re-write this whole section)
 
-The DOSBox core has the following option(s) that can be tweaked from the core options menu. The default setting is bolded.
+The DOSBox core has the following options that can be tweaked from the core options menu. The default setting is bolded.
 
 Settings with (Restart) mean that core has to be closed for the new setting to be applied on next launch.
 
@@ -325,6 +319,7 @@ Adjust the performance of the emulated CPU.
 	Fine tune the emulated performance for specific needs.
 
 ### Video Options
+Settings for the emulated graphics card and aspect ratio.
 
 - **Emulated Graphics Chip (restart required)** [dosbox_pure_machine] (**SVGA (Super Video Graphics Array) (default)** | VGA (Video Graphics Array) | EGA (Enhanced Graphics Adapter | CGA (Color Graphics Adapter) | Tandy (Tandy Graphics Adapter | Hercules (Hercules Graphics Card) | PCjr)
 
@@ -442,13 +437,7 @@ By clicking a key on the on-screen keyboard for 0.5 seconds, it will be held dow
 
 If the cursor is moved above the middle of the screen, the keyboard will move to the top. The button can be remapped in the controls menu and there is also a core option to disable it entirely.
 
-![#f03c15](https://via.placeholder.com/15/f03c15/000000?text=+) Note, the button can't be remapped (at present?) when using `Custom Keyboard Bindings`. cf. [bug #25](https://github.com/schellingb/dosbox-pure/issues/25)
-
 ## Joypad (RetroPad)
-!!!tip
-	There should be a run-down here of how the DOSBox Pure-specific features are mapped, e.g. the on-screen keyboard or the button combos to do things like force-open the start menu. Also, perhaps a quick guide to remapping. I noticed that only the custom mapping feature (cf. [bug #25](https://github.com/schellingb/dosbox-pure/issues/25) and [bug #14](https://github.com/schellingb/dosbox-pure/issues/14)) allows mapping of any keyboard key to any button, while it doesn't allow mapping the on-screen keyboard to a button. The others, like "Generic Keyboard Mapping", do allow mapping the on-screen keyboard, but they don't offer the full range of keyboard keys. For instance, in Generic Mapping, a user wouldn't be able to map the tab key to a controller button; they can only shuffle around the pre-defined keys.
-
-![#f03c15](https://via.placeholder.com/15/f03c15/000000?text=+) (This whole section needs to be double-checked/amended)
 
 | Input descriptors for Gamepad 2 Button | RetroPad Inputs                             |
 |----------------------------------------|---------------------------------------------|

--- a/docs/library/dosbox-pure.md
+++ b/docs/library/dosbox-pure.md
@@ -304,6 +304,10 @@ Keyboard, mouse and joystick settings.
 
 	Select the keyboard layout (will not change the On Screen Keyboard).
 
+- **Advanced > Menu Transparency** [dosbox_pure_joystick_analog_deadzone] (**15%** | 10% to 100% in 10% increments)
+
+	Set the transparency level of the On Screen Keyboard and the Gamepad Mapper.
+
 - **Advanced > Joystick Analog Deadzone** [dosbox_pure_joystick_analog_deadzone] (**15%** | 0% to 35% in 5% increments)
 
 	Set the deadzone of the joystick analog sticks. May be used to eliminate drift caused by poorly calibrated joystick hardware.

--- a/docs/library/dosbox-pure.md
+++ b/docs/library/dosbox-pure.md
@@ -360,7 +360,77 @@ If the cursor is moved above the middle of the screen, the keyboard will move to
 | Home/End                                | ![](../image/retropad/retro_right_stick.png) X |
 | PgUp/PgDn                               | ![](../image/retropad/retro_right_stick.png) Y |
 
-Above are the default keyboard to RetroPad mappings. Note that by using the Quick Menu, you can choose from various presets in the Controls > Port # Controls section.
+| Input descriptors for Keyboard - Port 2 | RetroPad Inputs                                |
+|-----------------------------------------|------------------------------------------------|
+| 8                                       | ![](../image/retropad/retro_dpad_up.png)       |
+| 2                                       | ![](../image/retropad/retro_dpad_down.png)     |
+| 4                                       | ![](../image/retropad/retro_dpad_left.png)     |
+| 6                                       | ![](../image/retropad/retro_dpad_right.png)    |
+| Period                                  | ![](../image/retropad/retro_select.png)        |
+| Enter                                   | ![](../image/retropad/retro_start.png)         |
+| 5                                       | ![](../image/retropad/retro_x.png)             |
+| 1                                       | ![](../image/retropad/retro_y.png)             |
+| 0                                       | ![](../image/retropad/retro_b.png)             |
+| 3                                       | ![](../image/retropad/retro_a.png)             |
+| 7                                       | ![](../image/retropad/retro_l1.png)            |
+| 9                                       | ![](../image/retropad/retro_r1.png)            |
+| Minus                                   | ![](../image/retropad/retro_l2.png)            |
+| Plus                                    | ![](../image/retropad/retro_r2.png)            |
+| Divide                                  | ![](../image/retropad/retro_l3.png)            |
+| Multiply                                | ![](../image/retropad/retro_r3.png)            |
+| 4/6                                     | ![](../image/retropad/retro_left_stick.png) X  |
+| 8/2                                     | ![](../image/retropad/retro_left_stick.png) Y  |
+| Minus/Plus                              | ![](../image/retropad/retro_right_stick.png) X |
+| Divide/Multiply                         | ![](../image/retropad/retro_right_stick.png) Y |
+
+| Input descriptors for Keyboard - Port 3 | RetroPad Inputs                                |
+|-----------------------------------------|------------------------------------------------|
+| Q                                       | ![](../image/retropad/retro_dpad_up.png)       |
+| A                                       | ![](../image/retropad/retro_dpad_down.png)     |
+| Z                                       | ![](../image/retropad/retro_dpad_left.png)     |
+| X                                       | ![](../image/retropad/retro_dpad_right.png)    |
+| G                                       | ![](../image/retropad/retro_select.png)        |
+| H                                       | ![](../image/retropad/retro_start.png)         |
+| D                                       | ![](../image/retropad/retro_x.png)             |
+| F                                       | ![](../image/retropad/retro_y.png)             |
+| C                                       | ![](../image/retropad/retro_b.png)             |
+| S                                       | ![](../image/retropad/retro_a.png)             |
+| W                                       | ![](../image/retropad/retro_l1.png)            |
+| E                                       | ![](../image/retropad/retro_r1.png)            |
+| R                                       | ![](../image/retropad/retro_l2.png)            |
+| T                                       | ![](../image/retropad/retro_r2.png)            |
+| V                                       | ![](../image/retropad/retro_l3.png)            |
+| B                                       | ![](../image/retropad/retro_r3.png)            |
+| Z/X                                     | ![](../image/retropad/retro_left_stick.png) X  |
+| Q/A                                     | ![](../image/retropad/retro_left_stick.png) Y  |
+| J/L                                     | ![](../image/retropad/retro_right_stick.png) X |
+| I/K                                     | ![](../image/retropad/retro_right_stick.png) Y |
+
+| Input descriptors for Keyboard - Port 4 | RetroPad Inputs                                |
+|-----------------------------------------|------------------------------------------------|
+| Backspace                               | ![](../image/retropad/retro_dpad_up.png)       |
+| Backslash                               | ![](../image/retropad/retro_dpad_down.png)     |
+| Semicolon                               | ![](../image/retropad/retro_dpad_left.png)     |
+| Quote                                   | ![](../image/retropad/retro_dpad_right.png)    |
+| O                                       | ![](../image/retropad/retro_select.png)        |
+| P                                       | ![](../image/retropad/retro_start.png)         |
+| Slash                                   | ![](../image/retropad/retro_x.png)             |
+| Right Shift                             | ![](../image/retropad/retro_y.png)             |
+| Right Ctrl                              | ![](../image/retropad/retro_b.png)             |
+| Right Alt                               | ![](../image/retropad/retro_a.png)             |
+| Left Bracket                            | ![](../image/retropad/retro_l1.png)            |
+| Right Bracket                           | ![](../image/retropad/retro_r1.png)            |
+| Comma                                   | ![](../image/retropad/retro_l2.png)            |
+| Period                                  | ![](../image/retropad/retro_r2.png)            |
+| Minus                                   | ![](../image/retropad/retro_l3.png)            |
+| Equals                                  | ![](../image/retropad/retro_r3.png)            |
+| Semicolon/Quote                         | ![](../image/retropad/retro_left_stick.png) X  |
+| Backspace/Backslash                     | ![](../image/retropad/retro_left_stick.png) Y  |
+| Left/Right Bracket                      | ![](../image/retropad/retro_right_stick.png) X |
+| Minus/Equals                            | ![](../image/retropad/retro_right_stick.png) Y |
+
+!!!tip
+	Above are the default keyboard to RetroPad mappings for all 4 ports. Note that by using the Quick Menu, you can choose from various presets in the `Controls` > `Port # Controls` section.
 
 | Input descriptors for Emulated mouse | RetroPad Inputs                                |
 |--------------------------------------|------------------------------------------------|

--- a/docs/library/dosbox-pure.md
+++ b/docs/library/dosbox-pure.md
@@ -19,7 +19,7 @@ A summary of the licenses behind RetroArch and its cores can be found [here](../
 
 Content that can be loaded by the DOSBox Pure core has the following file extensions:
 
-- .zip
+- .zip _(see [Load games from ZIP](#load-games-from-zip))_
 - .dosz _(alternative extension to .ZIP)_
 - .exe
 - .com
@@ -52,7 +52,7 @@ Frontend-level settings or features that the DOSBox Pure core respects.
 | Screenshots       | ✔         |
 | Saves             | ✔         |
 | States            | ✔         |
-| Rewind            | ✔         |
+| [Rewind](#rewind-support)            | ✔         |
 | Netplay           | ✕         |
 | Core Options      | ✔         |
 | RetroAchievements | ✕         |

--- a/docs/library/dosbox-pure.md
+++ b/docs/library/dosbox-pure.md
@@ -185,6 +185,7 @@ To play not with a gamepad but with keyboard and mouse, be sure to use the 'Game
 ### ZIP files can be renamed to DOSZ
 
 If your libretro frontend wants to load the content of `.ZIP` files instead of sending it to DOSBox Pure to load, the files can be renamed from `.ZIP` to `.DOSZ`.
+
 This is especially useful for CD images in ZIP format which RetroArch refuses to append through its `Disc Control` menu. Using an `.M3U8` file (see above) also avoids this problem.
 
 ### Force opening the start menu
@@ -442,7 +443,7 @@ By pressing L3 on the gamepad (usually by pushing in the left analog stick), the
 By clicking a key on the on-screen keyboard for 0.5 seconds, it will be held down, clicking it again will release it. This allows multiple keys to be pressed at the same time through the on-screen-keyboard.
 
 !!!tip
-	Depending on your controller, you might experience a slight drift (the cursor moving on its own). Fix this by going to `Settings > Input` in RetroArch and nudging the option `Analog Deadzone`up a bit (e.g., 0.3).
+	Depending on your controller, you might experience a slight drift (the cursor moving on its own). Fix this by going to `Settings > Input` in RetroArch and nudging the option `Analog Deadzone` up a bit (e.g., 0.3).
 
 If the cursor is moved above the middle of the screen, the keyboard will move to the top. The button can be remapped in the controls menu and there is also a core option to disable it entirely.
 

--- a/docs/library/dosbox-pure.md
+++ b/docs/library/dosbox-pure.md
@@ -317,6 +317,10 @@ Adjust the performance of the emulated CPU.
 
 	Fine tune the emulated performance for specific needs.
 
+- **Detailed > Limit CPU Usage** [dosbox_pure_cycle_limit] (**100%** | 20% to 100% in 1% increments)
+
+	When emulating DOS as fast as possible, how much time per frame should be used by the emulation. Lower this if your device becomes hot while using this core.
+
 ### Video Options
 Settings for the emulated graphics card and aspect ratio.
 

--- a/docs/library/dosbox-pure.md
+++ b/docs/library/dosbox-pure.md
@@ -132,6 +132,8 @@ Changes made to a loaded ZIP file will be stored as a separate ZIP file into the
 
 CD images (ISO or CUE) and floppy disk images (IMG/IMA/VHD) can be mounted directly from inside ZIP files. The system will automatically mount the first found disk image as the A: or D: drive. Additional disks can be loaded or swapped by using the `Disc Control` menu in RetroArch.
 
+When mounting a ZIP file which has just a single directory in its root, core versions before 0.9.0 used to mount that directory as the C: drive. Now the core will mount the root of the ZIP to improve compatibility with DOS games that need to be installed in a specific location on the hard drive. The old behavior will still be used if an old save file (named `GAME.save.zip`) exists. The new behavior uses a differently named save file (`GAME.pure.zip`).
+
 The start menu also offers the option to mount or unmount an image.
 
 ### Start menu with auto start

--- a/docs/library/dosbox-pure.md
+++ b/docs/library/dosbox-pure.md
@@ -116,6 +116,10 @@ The DOSBox Pure core's library name is 'DOSBox-Pure'.
 
 ## Loading content
 
+### loading of dosbox.conf files
+
+DOSBox Pure can boot directly from a .conf file or it will load C:\DOSBOX.CONF automatically if it exists in the mounted ZIP or path.
+
 ### Load games from ZIP
 
 DOSBox Pure can load games directly from ZIP files without the need to extract them.
@@ -142,12 +146,6 @@ If there is only a single executable, the menu will not show and directly run th
 
 To force the menu to be shown, hold shift on the keyboard or L2 or R2 on the gamepad while selecting `Restart` in the core menu.
 
-### Directly run PC booter games from the start menu
-
-![Directly run PC booter games from the start menu](https://user-images.githubusercontent.com/14200249/164041304-f921c806-8790-4bee-b9fa-5826714012e3.gif)
-
-In addition, there's support for swapping floppy disk images (or PCjr cartridges) at runtime via a frontend's Disc Control menu and hotkeys.
-
 ### Installing CD-ROM games from disc images (ISO etc.) and running them
 
 In order to install a game from a CD-ROM image (e.g., a .iso file), use the "Load Content" option in the RetroArch main menu. Navigate to the ISO and launch it with the DOSBox Pure core.
@@ -157,6 +155,10 @@ From the start menu, select the executable on the CD-ROM to install the game (pr
 Now, the next time you run the ISO in DOSBox Pure (same way as above), the start menu will feature the "local" executables, e.g.: `C:\C&C\C&C.EXE`. They'll be available to select above the executables from mounted discs. Launch the correct executable to run the game.
 
 See screenshot in "Start menu with auto start" section above for reference.
+
+### Directly run PC booter games from the start menu
+
+![Directly run PC booter games from the start menu](https://user-images.githubusercontent.com/14200249/164041304-f921c806-8790-4bee-b9fa-5826714012e3.gif)
 
 ### Loading M3U8 files
 
@@ -214,10 +216,6 @@ When modifications to the file system loaded from a ZIP file happen, these modif
 - Up to 1MB of total save data, it will be written out 2 seconds after the previous file modification. Then gradually until at max 59MB and more, it will be written out 60 seconds after the last file modification.
 
 ## Features currently not implemented
-
-### Load dosbox.conf
-
-It would be nice to be able to load a dosbox.conf file if it exists in the loaded game directory (for example inside the ZIP file). Ideally this would then hide all the options that have been overwritten by that .conf file in the core options list.
 
 ### Store ZIP seek index into save file
 
@@ -445,6 +443,16 @@ By clicking a key on the on-screen keyboard for 0.5 seconds, it will be held dow
 	Depending on your controller, you might experience a slight drift (the cursor moving on its own). Fix this by going to `Settings > Input` in RetroArch and nudging the option `Analog Deadzone`up a bit (e.g., 0.3).
 
 If the cursor is moved above the middle of the screen, the keyboard will move to the top. The button can be remapped in the controls menu and there is also a core option to disable it entirely.
+
+### Gamepad Mapper
+
+![The DOSBox Pure gamepad mapper](https://raw.githubusercontent.com/schellingb/dosbox-pure/main/images/padmapper.png)
+
+If you need even more customization of the controls than provided by the Automated controller mappings, or the various presets for mouse, keyboard and joysticks you can use the gamepad mapper introduced in version 0.9.0 in April, 2022.
+
+To open it, click the "PAD MAPPER" button in the On-screen keyboard (cf. above).
+
+It is available any time in-game and changes are immediately saved and applied when closing the mapper. Up to 4 functions can be mapped for any button/direction of the gamepad. A mapping can be to any function of the 3 emulated input devices: keyboard, mouse or joystick.
 
 ## Joypad (RetroPad)
 

--- a/docs/library/dosbox-pure.md
+++ b/docs/library/dosbox-pure.md
@@ -707,7 +707,18 @@ It is available any time in-game and changes are immediately saved and applied w
 ## Compatibility
 
 ### Boppin'
-If the game rapidly cycles through the main menu options indefinitely, open the RetroArch Quick Menu and select Controls > Port 2 Controls > Device Type > Disabled.
+If the game rapidly cycles through the main menu options indefinitely, it has to do with malfunctioning joystick calibration. try deleting the game's config file, `BOPPIN.CFG`, and then reconfiguring the game. To do so, leave the game and from the command line, type:
+
+`CD BOPPIN
+DEL BOPPIN.CFG
+SETUP.EXE
+BOPPIN.EXE`
+
+To fix this in-game, you need to go to the core options and fiddle around with the Emulated Performance setting until the cursor stops moving.
+
+Boppin' uses some form of joystick calibration which depends on the speed of the CPU. And it seems that once it has some form of calibration data, it saves that to its config file. So if you use the game pre-configured while running with different performance emulation (cycles) settings, it will have its joysticks off-calibrated and thus scrolling through the main menu (always holding up or down) or switching between the title screen and the menu (always holding left or right).
+
+[More info here](https://github.com/schellingb/dosbox-pure/issues/75#issuecomment-1115108702).
 
 ## External Links
 

--- a/docs/library/dosbox-pure.md
+++ b/docs/library/dosbox-pure.md
@@ -179,7 +179,11 @@ You might have trouble getting stutter-free scrolling in some games (cf. [this b
 
 ### Playing with keyboard and mouse
 
-To play not with a gamepad but with keyboard and mouse, be sure to use the 'Game Focus' mode available in RetroArch. By default you can toggle game focus by pressing the scroll lock key. While game focus is active, the RetroArch hotkeys are disabled and keyboard presses will not cause [RetroPad](https://docs.libretro.com/guides/input-and-controls/) button presses (which could cause multiple keys to be pressed at once).
+To play not with a gamepad but with keyboard and mouse, be sure to use the '[Game Focus](https://docs.libretro.com/guides/input-and-controls/#cores-with-direct-keyboard-input)' mode available in RetroArch.
+
+By default, you can toggle game focus by pressing the scroll lock key. While game focus is active, the RetroArch hotkeys are disabled and keyboard presses will not cause [RetroPad](https://docs.libretro.com/guides/input-and-controls/) button presses (which could cause multiple keys to be pressed at once).
+
+You can change the hotkey for game focus mode in RetroArch's ["Hotkeys" menu](https://docs.libretro.com/guides/input-and-controls/#hotkeys).
 
 ### ZIP files can be renamed to DOSZ
 

--- a/docs/library/dosbox-pure.md
+++ b/docs/library/dosbox-pure.md
@@ -14,7 +14,6 @@ The DOSBox-Pure core has been authored by
 The DOSBox core is licensed under
 
 - [GPLv2](https://github.com/libretro/dosbox-libretro/blob/master/COPYING)
-![#f03c15](https://via.placeholder.com/15/f03c15/000000?text=+) (I presume?)
 
 A summary of the licenses behind RetroArch and its cores can be found [here](../development/licenses.md).
 ![#f03c15](https://via.placeholder.com/15/f03c15/000000?text=+) (This is a relative URL, so I'm guessing it will work correctly when this file lands on the master?)

--- a/docs/library/dosbox-pure.md
+++ b/docs/library/dosbox-pure.md
@@ -707,7 +707,7 @@ It is available any time in-game and changes are immediately saved and applied w
 ## Compatibility
 
 ### Boppin'
-If the game quickly cycles through the main menu options indefinitely, open the RetroArch Quick Menu and select Controls > Port 2 Controls > Device Type > Disabled.
+If the game rapidly cycles through the main menu options indefinitely, open the RetroArch Quick Menu and select Controls > Port 2 Controls > Device Type > Disabled.
 
 ## External Links
 

--- a/docs/library/dosbox-pure.md
+++ b/docs/library/dosbox-pure.md
@@ -163,7 +163,7 @@ There's also support for swapping floppy disk images (or PCjr cartridges) at run
 
 ### Auto-execution of DOSBOX.BAT
 
-The core automatically executes "DOSBOX.BAT" instead of showing the start menu if it exists in the mounted ZIP or path.
+The core automatically executes `DOSBOX.BAT` instead of showing the start menu if it exists in the mounted ZIP or path.
 
 ### Loading M3U8 files
 

--- a/docs/library/dosbox-pure.md
+++ b/docs/library/dosbox-pure.md
@@ -8,7 +8,8 @@ DOSBox Pure is fork of the multiplatform MS-DOS emulator, DOSBox. It was built b
 
 The DOSBox-Pure core has been authored by
 
-- Bernhard Schelling
+- DOSBox Team
+- Psyraven
 
 The DOSBox core is licensed under
 
@@ -22,16 +23,19 @@ A summary of the licenses behind RetroArch and its cores can be found [here](../
 
 Content that can be loaded by the DOSBox Pure core has the following file extensions:
 
+- .zip
+- .dosz (alternative extension to .ZIP)
 - .exe
 - .com
 - .bat
-- .conf
 - .iso
 - .cue
+- .ins
 - .img
 - .ima
 - .vhd
-- .zip
+- .m3u
+- .m3u8
 
 RetroArch database(s) that are associated with the DOSBox core:
 
@@ -39,7 +43,8 @@ RetroArch database(s) that are associated with the DOSBox core:
 ![#f03c15](https://via.placeholder.com/15/f03c15/000000?text=+) (Others?)
 
 ## Features
-![#f03c15](https://via.placeholder.com/15/f03c15/000000?text=+) (We should embed the [YouTube video](https://www.youtube.com/watch?v=rHkIz4-SewI) here!)
+!!!tip
+	DOSBox Pure has its own [trailer on YouTube](https://www.youtube.com/watch?v=rHkIz4-SewI)
 
 Frontend-level settings or features that the DOSBox Pure core respects.
 ![#f03c15](https://via.placeholder.com/15/f03c15/000000?text=+) (Is this correct? Should we expand this table?)
@@ -54,7 +59,7 @@ Frontend-level settings or features that the DOSBox Pure core respects.
 | Netplay           | ✕         |
 | Core Options      | ✔         |
 | RetroAchievements | ✕         |
-| RetroArch Cheats  | ✕         |
+| RetroArch Cheats  | ✔         |
 | Native Cheats     | ✔         |
 | Controls          | ✔         |
 | Remapping         | ✔         |
@@ -105,13 +110,13 @@ The DOSBox Pure core's library name is 'DOSBox-Pure'.
 
 ## Geometry and timing
 
-- The DOSBox Pure core's core provided FPS is 60.0
-- The DOSBox Pure core's core provided sample rate is (Rate)
+- The DOSBox Pure core's core provided FPS is dependent on the DOS application
+- The DOSBox Pure core's core provided sample rate is dependent on the 'Audio > Audio Sample Rate' core option
 - The DOSBox Pure core's base width is 320
 - The DOSBox Pure core's base height is 200
-- The DOSBox Pure core's max width is 1024
-- The DOSBox Pure core's max height is 768
-- The DOSBox Pure core's core provided aspect ratio is 4/3
+- The DOSBox Pure core's max width is 1280
+- The DOSBox Pure core's max height is 1024
+- The DOSBox Pure core's core provided aspect ratio is dependent on the DOS application and the 'Video > Aspect Ratio Correction' core option
 
 ## Loading content
 
@@ -156,6 +161,15 @@ See screenshot in "Start menu with auto start" section above for reference.
 If the core gets loaded with a `.m3u8` file, all files listed in it will be added to the disc swap menu. The first image will automatically get mounted as the A: or D: drive depending on whether it is a CD or floppy disk image.
 
 ## Tips, Q&A, Troubleshooting
+
+### Smooth scrolling
+
+You might have trouble getting stutter-free scrolling in some games (cf. https://github.com/schellingb/dosbox-pure/issues/128). There are a number of things you can try to remedy this:
+
+- In RetroArch's settings, navigate to `Video` and set `Threaded Video` to OFF.
+- Try `Video` > `Output` > `Set Display-Reported Refresh Rate`.
+- Try setting `Video` > `Synchronization` > `Vertical Sync` to ON.
+- If using a variable refresh rate screen (G-Sync, FreeSync, HDMI 2.1 VRR): navigate to `Video` > `Synchronization` and set `Sync to Exact Content Framerate (G-Sync, FreeSync)` to ON.
 
 ### Playing with keyboard and mouse
 

--- a/docs/library/dosbox-pure.md
+++ b/docs/library/dosbox-pure.md
@@ -34,7 +34,7 @@ Content that can be loaded by the DOSBox Pure core has the following file extens
 - .tc
 - .m3u
 - .m3u8
-- .conf _(bootable, [more info here](#loading-of-dosboxconf-files))_
+- .conf _(bootable, see [Loading of dosbox.conf files](#loading-of-dosboxconf-files))_
 
 RetroArch database(s) that are associated with the DOSBox core:
 

--- a/docs/library/dosbox-pure.md
+++ b/docs/library/dosbox-pure.md
@@ -233,7 +233,36 @@ For now, serial port and IPX emulation from base DOSBox have been removed.
 
 The DOSBox core has the following option(s) that can be tweaked from the core options menu. The default setting is bolded.
 
-Settings with (Restart) means that core has to be closed for the new setting to be applied on next launch.
+Settings with (Restart) mean that core has to be closed for the new setting to be applied on next launch.
+
+### Save States Support (**Enable save states** | Enable save states with rewind | Off)
+
+Make sure to test it in each game before using it. Complex late era DOS games might have problems. Be aware that states saved with different video, CPU or memory settings are not loadable. Rewind support comes at a high performance cost and needs at least 40MB of rewind buffer. Save states might not be compatible with new versions of this core.
+
+### Input Options
+
+- **Bind Unused Buttons** [dosbox_pure_bind_unused] (**On** | Off)
+
+	Bind all unused controller buttons to keyboard keys. Can be remapped in the Controls section of the core settings.
+
+- **Enable On Screen Keyboard** [dosbox_pure_on_screen_keyboard] (**On** | Off)
+
+	 Enable the On Screen Keyboard feature which can be activated with the L3 button on the controller.
+
+- **Bind Mouse Wheel To Key** [dosbox_pure_mouse_wheel] (**Left-Bracket/Right-Bracket** | Comma/Period | Page-Up/Page-Down | Home/End | Delete/Page-Down | Minus/Equals | Semicolon/Quote | Numpad Minus/Plus | Numpad Divide/Multiply | Up/Down | Left/Right | Q/E | Disable)
+
+	Bind mouse wheel up and down to two keyboard keys to be able to use it in DOS games.
+
+- **Mouse Sensitivity** [dosbox_pure_mouse_speed_factor] (**1.0** | 0.2 to 1.0 in .05 increments | 1.0 to 5.0 in .1 increments)
+
+	Sets the overall mouse cursor movement speed.
+ 
+- **Advanced > Horizontal Mouse Sensitivity** [dosbox_pure_mouse_speed_factor_x] (**1.0** | 0.2 to 1.0 in .05 increments | 1.0 to 5.0 in .1 increments)
+
+	Experiment with this value if the mouse is too fast/slow when moving left/right.
+
+
+================================================
 
 - **Machine type** [dosbox_machine_type] (**vgaonly**|svga_s3|svga_et3000|svga_et4000|svga_paradise|hercules|cga|tandy|pcjr|ega)
 

--- a/docs/library/dosbox-pure.md
+++ b/docs/library/dosbox-pure.md
@@ -284,7 +284,9 @@ These can be assigned to any port and the button layout can be remapped as with 
 
 ![DOSBox Pure On-Screen Keyboard](https://github.com/schellingb/dosbox-pure/blob/main/images/onscreenkeyboard.png)
 
-By pressing L3 on the gamepad (usually by pushing in the left analog stick) the on-screen keyboard will open. The cursor can be controlled with the controller (or mouse or keyboard) and L2/R2 will speed up or slow down the move speed.
+By pressing L3 on the gamepad (usually by pushing in the left analog stick), the on-screen keyboard will open. The cursor can be controlled with the controller (or mouse or keyboard) and L2/R2 will speed up or slow down the move speed.
+
+By clicking a key on the on-screen keyboard for 0.5 seconds, it will be held down, clicking it again will release it. This allows multiple keys to be pressed at the same time through the on-screen-keyboard.
 
 !!!tip
 	Depending on your controller, you might experience a slight drift (the cursor moving on its own). Fix this by going to `Settings > Input` in RetroArch and nudging the option `Analog Deadzone`up a bit (e.g., 0.3).

--- a/docs/library/dosbox-pure.md
+++ b/docs/library/dosbox-pure.md
@@ -304,7 +304,7 @@ Keyboard, mouse and joystick settings.
 
 	Select the keyboard layout (will not change the On Screen Keyboard).
 
-- **Advanced > Menu Transparency** [dosbox_pure_joystick_analog_deadzone] (**15%** | 10% to 100% in 10% increments)
+- **Advanced > Menu Transparency** [dosbox_pure_menu_transparency] (**15%** | 10% to 100% in 10% increments)
 
 	Set the transparency level of the On Screen Keyboard and the Gamepad Mapper.
 

--- a/docs/library/dosbox-pure.md
+++ b/docs/library/dosbox-pure.md
@@ -44,10 +44,9 @@ RetroArch database(s) that are associated with the DOSBox core:
 
 ## Features
 !!!tip
-	DOSBox Pure has its own [trailer on YouTube](https://www.youtube.com/watch?v=rHkIz4-SewI)
+	DOSBox Pure has its own [trailer on YouTube](https://www.youtube.com/watch?v=rHkIz4-SewI).
 
 Frontend-level settings or features that the DOSBox Pure core respects.
-![#f03c15](https://via.placeholder.com/15/f03c15/000000?text=+) (Is this correct? Should we expand this table?)
 
 | Feature           | Supported |
 |-------------------|:---------:|

--- a/docs/library/dosbox-pure.md
+++ b/docs/library/dosbox-pure.md
@@ -161,6 +161,10 @@ When loading a ZIP file which contains a floppy or hard-disk image or loading su
 
 There's also support for swapping floppy disk images (or PCjr cartridges) at runtime via a frontend's Disc Control menu and hotkeys.
 
+### Auto-execution of DOSBOX.BAT
+
+The core automatically executes "DOSBOX.BAT" instead of showing the start menu if it exists in the mounted ZIP or path.
+
 ### Loading M3U8 files
 
 If the core gets loaded with a `.m3u8` file, all files listed in it will be added to the disc swap menu. The first image will automatically get mounted as the A: or D: drive depending on whether it is a CD or floppy disk image.

--- a/docs/library/dosbox-pure.md
+++ b/docs/library/dosbox-pure.md
@@ -34,7 +34,7 @@ Content that can be loaded by the DOSBox Pure core has the following file extens
 - .tc
 - .m3u
 - .m3u8
-- .conf _(bootable; booting a dosbox.conf file will mount the directory as C: and load/autoexec the conf file)_
+- .conf _(bootable, [more info here](#loading-of-dosboxconf-files))_
 
 RetroArch database(s) that are associated with the DOSBox core:
 
@@ -75,7 +75,7 @@ Frontend-level settings or features that the DOSBox Pure core respects.
 
 ### MIDI playback with SoundFonts
 
-If DOSBox Pure finds one or more `.SF2` sound font files in the `system` directory of the frontend, one of them can be selected via the `Audio > MIDI Output` [core option](#core-options). This sound font will then be used to play `General Midi` and `Sound Canvas` music.
+If DOSBox Pure finds one or more `.SF2` sound font files in the `system` directory of the frontend, one of them can be selected via the `Audio > MIDI Output` [core option](#audio-options). This sound font will then be used to play `General Midi` and `Sound Canvas` music.
 
 ###  MPU-401 MIDI device emulation through MUNT
 
@@ -91,18 +91,18 @@ For details how to use it and how to find new cheats while playing the game, che
 
 ### Save states
 
-The DOSBox Pure core fully supports libretro save states. Make sure to test it in each game before using it. Complex late era DOS games might have problems.
+The DOSBox Pure core fully supports libretro save states. Make sure to test it in each game before using it. Complex late era DOS games might have problems. Be aware that states saved with different video or cpu settings are not loadable.
 
-Be aware that states saved with different video or cpu settings are not loadable.
+Read more about [save file handling](#save-file-handling).
 
 ### Rewind support
 
-Using the core option `Save States Support`, rewinding can be enabled. Keep in mind that rewind support comes at a high performance cost.
+Using the [core option](#emulation-options) `Save States Support`, rewinding can be enabled. Keep in mind that rewind support comes at a high performance cost.
 
 ## Geometry and timing
 
 - The DOSBox Pure core's core provided FPS is dependent on the DOS application
-- The DOSBox Pure core's core provided sample rate is dependent on the 'Audio > Audio Sample Rate' core option
+- The DOSBox Pure core's core provided sample rate is dependent on the 'Audio > Audio Sample Rate' [core option](#audio-options)
 - The DOSBox Pure core's base width is 320
 - The DOSBox Pure core's base height is 200
 - The DOSBox Pure core's max width is 1280
@@ -121,13 +121,13 @@ DOSBox Pure can load games directly from ZIP files without the need to extract t
 
 ### Store modifications in separate save files
 
-Changes made to a loaded ZIP file will be stored as a separate ZIP file into the libretro saves directory. If a game is loaded directly without using a ZIP file the saves directory is not used.
+Changes made to a loaded ZIP file will be stored as a separate ZIP file into the [libretro saves directory](https://docs.libretro.com/guides/change-directories/#savefile-and-savestate). If a game is loaded directly without using a ZIP file, the saves directory is not used.
 
 ### Mount disc images from inside ZIP files
 
 CD images (ISO or CUE) and floppy disk images (IMG/IMA/VHD) can be mounted directly from inside ZIP files. The system will automatically mount the first found disk image as the A: or D: drive. Additional disks can be loaded or swapped by using the `Disc Control` menu in RetroArch.
 
-When mounting a ZIP file which has just a single directory in its root, core versions before 0.9.0 used to mount that directory as the C: drive. Now the core will mount the root of the ZIP to improve compatibility with DOS games that need to be installed in a specific location on the hard drive. The old behavior will still be used if an old save file (named `GAME.save.zip`) exists. The new behavior uses a differently named save file (`GAME.pure.zip`).
+When mounting a ZIP file which has just a single directory in its root, core versions before 0.9.0 used to mount that directory as the C: drive. Since 0.9.0, the core will mount the root of the ZIP to improve compatibility with DOS games that need to be installed in a specific location on the hard drive. The old behavior will still be used if an old save file (named `GAME.save.zip`) exists. The new behavior uses a differently named save file (`GAME.pure.zip`).
 
 The start menu also offers the option to mount or unmount an image.
 
@@ -145,13 +145,13 @@ To force the menu to be shown, hold shift on the keyboard or L2 or R2 on the gam
 
 ### Installing CD-ROM games from disc images (ISO etc.) and running them
 
-In order to install a game from a CD-ROM image (e.g., a .iso file), use the "Load Content" option in the RetroArch main menu. Navigate to the ISO and launch it with the DOSBox Pure core.
+This can be done in 3 steps:
 
-From the start menu, select the executable on the CD-ROM to install the game (probably something like `SETUP.EXE`, `INSTALL.EXE`, `START.EXE`...). Follow the installer's instructions to install the game in any local directory of your choice (e.g., `C:\`, `C:\C&C\`, ...).
+1. In order to install a game from a CD-ROM image (e.g., a .iso file), use the "Load Content" option in the RetroArch main menu. Navigate to the ISO and launch it with the DOSBox Pure core.
+2. From the start menu, select the executable on the CD-ROM to install the game (probably something like `SETUP.EXE`, `INSTALL.EXE`, `START.EXE`...). Follow the installer's instructions to install the game in any local directory of your choice (e.g., `C:\`, `C:\C&C\`, ...).
+3. Now, the next time you run the ISO in DOSBox Pure (same way as in step 1 above), the start menu will feature the "local" executables, e.g.: `C:\C&C\C&C.EXE`. They'll be available to select above the executables from mounted discs. Launch the correct executable to run the game.
 
-Now, the next time you run the ISO in DOSBox Pure (same way as above), the start menu will feature the "local" executables, e.g.: `C:\C&C\C&C.EXE`. They'll be available to select above the executables from mounted discs. Launch the correct executable to run the game.
-
-See screenshot in "Start menu with auto start" section above for reference.
+See screenshot in "[Start menu with auto start](#start-menu-with-auto-start)" section above for reference.
 
 ### Directly run PC booter games from the start menu
 
@@ -169,7 +169,7 @@ If the core gets loaded with a `.m3u8` file, all files listed in it will be adde
 
 ### Smooth scrolling
 
-You might have trouble getting stutter-free scrolling in some games (cf. https://github.com/schellingb/dosbox-pure/issues/128). There are a number of things you can try to remedy this:
+You might have trouble getting stutter-free scrolling in some games (cf. [this bug report](https://github.com/schellingb/dosbox-pure/issues/128)). There are a number of things you can try to remedy this:
 
 - In `Quick Menu > Options > Emulation Options`, set `Force 60 FPS Output` to ON.
 - In RetroArch's settings, navigate to `Video` and set `Threaded Video` to OFF.

--- a/docs/library/dosbox-pure.md
+++ b/docs/library/dosbox-pure.md
@@ -237,6 +237,7 @@ The DOSBox core has the following option(s) that can be tweaked from the core op
 Settings with (Restart) mean that core has to be closed for the new setting to be applied on next launch.
 
 ### Manage Core Options
+Save or remove option overrides for the current content.
 
 - **Reset Options**
 
@@ -270,6 +271,7 @@ Core specific settings (latency, save states, start menu).
 	In low latency mode when emulating DOS as fast as possible, how much time per frame should be used by the emulation. If the video is stuttering, lower this or improve render performance in the frontend (for example by disabling vsync or video processing). Use the performance statistics to easily find the maximum that still hits the emulated target framerate.
 
 ### Input Options
+Keyboard, mouse and joystick settings.
 
 - **Bind Unused Buttons** [dosbox_pure_bind_unused] (**On** | Off)
 
@@ -312,8 +314,9 @@ Core specific settings (latency, save states, start menu).
 	Enable timed intervals for joystick axes. Experiment with this option if your joystick drifts.
 
 ### Performance Options
+Adjust the performance of the emulated CPU.
 
-- **Emulated Performance** [dosbox_pure_cycles] (**AUTO - DOSBox will try to detect performance needs (default)** | MAX - Emulate as many instructions as possible | 8086/8088, 4.77 MHz from 1980 (315 cps) | 286, 6 MHz from 1982 (1320 cps) | 286, 12.5 MHz from 1985 (2750 cps) | 386, 20 MHz from 1987 (4720 cps) |  | 386DX, 33 MHz from 1989 (7800 cps) | 486DX, 33 MHz from 1990 (13400 cps) | 486DX2, 66 MHz from 1992 (26800 cps) | Pentium, 100 MHz from 1995 (77000 cps) | Pentium II, 300 MHz from 1997 (200000 cps) | Pentium III, 600 MHz from 1999 (500000 cps) | AMD Athlon, 1.2 GHz from 2000 (1000000 cps))
+- **Emulated Performance** [dosbox_pure_cycles] (**AUTO - DOSBox will try to detect performance needs (default)** | MAX - Emulate as many instructions as possible | 8086/8088, 4.77 MHz from 1980 (315 cps) | 286, 6 MHz from 1982 (1320 cps) | 286, 12.5 MHz from 1985 (2750 cps) | 386, 20 MHz from 1987 (4720 cps) | 386DX, 33 MHz from 1989 (7800 cps) | 486DX, 33 MHz from 1990 (13400 cps) | 486DX2, 66 MHz from 1992 (26800 cps) | Pentium, 100 MHz from 1995 (77000 cps) | Pentium II, 300 MHz from 1997 (200000 cps) | Pentium III, 600 MHz from 1999 (500000 cps) | AMD Athlon, 1.2 GHz from 2000 (1000000 cps))
 
 	The raw performance that DOSBox will try to emulate.
 
@@ -323,101 +326,74 @@ Core specific settings (latency, save states, start menu).
 
 ### Video Options
 
-- **** [] (**** |  |  |  |)
+- **Emulated Graphics Chip (restart required)** [dosbox_pure_machine] (**SVGA (Super Video Graphics Array) (default)** | VGA (Video Graphics Array) | EGA (Enhanced Graphics Adapter | CGA (Color Graphics Adapter) | Tandy (Tandy Graphics Adapter | Hercules (Hercules Graphics Card) | PCjr)
 
+	The type of graphics chip that DOSBox will emulate.
 
+- **CGA Mode** [dosbox_pure_cga] (**Early model, composite mode auto (default)** | Early model, composite mode on | Early model, composite mode off | Late model, composite mode auto | Late model, composite mode on | Late model, composite mode off)
 
-- **** [] (**** |  |  |  |)
+	The CGA variation that is being emulated.
 
+- **Hercules Color Mode** [dosbox_pure_hercules] (**Black & white (default)** | Black & amber | Black & green)
 
+	The color scheme for Hercules emulation.
 
-- **** [] (**** |  |  |  |)
+- **SVGA Mode (restart required)** [dosbox_pure_svga] (**S3 Trio64 (default)** | S3 Trio64 no-line buffer hack (reduces flickering in some games) | S3 Trio64 VESA 1.3 | Tseng Labs ET3000 | Tseng Labs ET4000 | Paradise PVGA1A)
 
+	The SVGA variation that is being emulated. Try changing this if you encounter graphical glitches.
 
+- **Aspect Ratio Correction** [dosbox_pure_aspect_correction] (**Off (default)** | On)
 
-- **** [] (**** |  |  |  |)
+	When enabled, the core's aspect ratio is set to what a CRT monitor would display.
 
+### System Options
+Other system settings for emulated RAM and CPU.
 
-- **** [] (**** |  |  |  |)
+- **Memory Size (restart required)** [dosbox_pure_memory_size] (**16 MB (default)** | Disable extended memory (no EMS/XMS) | 4 MB | 8 MB | 24 MB | 32 MB (unsafe) | 48 MB (unsafe) | 64 MB (unsafe) | 96 MB (unsafe) | 128 MB (unsafe) | 224 MB (unsafe))
 
+	The amount of (high) memory that the emulated machine has. You can also disable extended memory (EMS/XMS). Using more than the default is not recommended, due to incompatibility with certain games and applications.
 
-- **** [] (**** |  |  |  |)
+- **CPU Type (restart required)** [dosbox_pure_cpu_type] (**Auto - Mixed feature set with maximum performance and compatibility** | 386 - 386 instruction with fast memory access | 386 (slow) - 386 instruction set with memory privilege checks | 386 (prefetch) - With prefetch queue emulation (only on 'auto' and 'normal' core) | 486 (slow) - 486 instruction set with memory privilege checks | Pentium (slow) - 586 instruction set with memory privilege checks)
 
+	Emulated CPU type. Auto is the fastest choice. Games that require specific CPU type selection:
+	386 (prefetch): X-Men: Madness in The Murderworld, Terminator 1, Contra, Fifa International Soccer 1994
+	486 (slow): Betrayal in Antara
+	Pentium (slow): Fifa International Soccer 1994, Windows 95/Windows 3.x games
 
+- **Advanced > CPU Core (restart required)** [dosbox_pure_cpu_core] (**Auto - Real-mode games use normal, protected-mode games use dynamic** | Dynamic - Dynamic recompilation (fast, using dynamic_x86 implementation) | Auto - Real-mode games use normal, protected-mode games use dynamic | Dynamic - Dynamic recompilation (fast, using dynrec implementation) | **Normal (interpreter)** | Simple (interpreter optimized for old real-mode games))
 
-- **** [] (**** |  |  |  |)
+	Emulation method (DOSBox CPU core) used.
 
+### Audio Options
+MIDI, SoundBlaster and other audio settings.
 
+- **Audio Sample Rate (restart required)** [dosbox_pure_audiorate] (48000 | 44100 | 32730 | 32000 | 22050 | 16000 | 11025 | 8000 | 49716)
 
-- **** [] (**** |  |  |  |)
+	This should match the frontend audio output rate (Hz) setting. 49716 is for perfect OPL emulation.
 
+- **SoundBlaster Settings** [dosbox_pure_sblaster_conf] (**Port 0x220, IRQ 7, 8-Bit DMA 1, 16-bit DMA 5** | Port 0x220, IRQ 5, 8-Bit DMA 1, 16-bit DMA 5 | Port 0x240, IRQ 7, 8-Bit DMA 1, 16-bit DMA 5 | Port 0x240, IRQ 7, 8-Bit DMA 3, 16-bit DMA 7 | Port 0x240, IRQ 2, 8-Bit DMA 3, 16-bit DMA 7 | Port 0x240, IRQ 5, 8-Bit DMA 3, 16-bit DMA 5 | Port 0x240, IRQ 5, 8-Bit DMA 1, 16-bit DMA 5 | Port 0x240, IRQ 10, 8-Bit DMA 3, 16-bit DMA 7 | Port 0x280, IRQ 10, 8-Bit DMA 0, 16-bit DMA 6 | Port 0x210, IRQ 5, 8-Bit DMA 1, 16-bit DMA 5)
 
+	Set the address, interrupt, low 8-bit and high 16-bit DMA.
 
+- **MIDI Output** [dosbox_pure_midi] (will cycle through the .ROMs or .SF2s you have installed, + frontend MIDI driver)
 
+	Select the .SF2 SoundFont file, .ROM file or interface used for MIDI output. To add SoundFonts or ROM files, copy them into the 'system' directory of the frontend. To use the frontend MIDI driver, make sure it's set up correctly.
 
-- **** [] (**** |  |  |  |)
+- **Advanced > SoundBlaster Type** [dosbox_pure_sblaster_type] (**SoundBlaster 16 (default)** | SoundBlaster Pro 2 | SoundBlaster Pro | SoundBlaster 2.0 | SoundBlaster 1.0 | GameBlaster | none)
 
+	Type of emulated SoundBlaster card.
 
+- **Advanced > SoundBlaster Adlib/FM Mode** [dosbox_pure_sblaster_adlib_mode] (**Auto (select based on the SoundBlaster type) (default)** | CMS (Creative Music System / GameBlaster) | OPL-2 (AdLib / OPL-2 / Yamaha 3812) | Dual OPL-2 (Dual OPL-2 used by SoundBlaster Pro 1.0 for stereo sound) | OPL-3 (AdLib / OPL-3 / Yamaha YMF262) | OPL-3 Gold (AdLib Gold / OPL-3 / Yamaha YMF262))
 
+	The SoundBlaster emulated FM synth mode. All modes are Adlib compatible except CMS.
 
-- **** [] (**** |  |  |  |)
+- **Advanced > SoundBlaster Adlib Provider** [dosbox_pure_sblaster_adlib_emu] (**Default** | High quality Nuked OPL3)
 
+	Provider for the Adlib emulation. Default has good quality and low performance requirements.
 
+- **Advanced > Enable Gravis Ultrasound (restart required)** [dosbox_pure_gus] (**Off (default)** | On)
 
-
-- **** [] (**** |  |  |  |)
-
-
-- **** [] (**** |  |  |  |)
-
-
-- **** [] (**** |  |  |  |)
-
-
-- **** [] (**** |  |  |  |)
-
-
-- **** [] (**** |  |  |  |)
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-================================================
-
-- **Machine type** [dosbox_machine_type] (**vgaonly**|svga_s3|svga_et3000|svga_et4000|svga_paradise|hercules|cga|tandy|pcjr|ega)
-
-	Select what machine will be emulated.
-
-- **Gamepad emulated mouse** [dosbox_emulated_mouse] (**enable**|disable)
-
-	CPU cycles are divided in core options to allow fine control of the desired CPU cycles. Setting this too low may cause slow gameplay, setting this too high might cause sound crackling and bad performance.
-
-- **CPU cycles x 100000** [dosbox_cpu_cycles_0] (**0**|1|2|3|4|5|6|7|8|9)
-
-	CPU cycles are divided in core options to allow fine control of the desired CPU cycles. Setting this too low may cause slow gameplay, setting this too high might cause sound crackling and bad performance.
-
-- **CPU cycles x 10000** [dosbox_cpu_cycles_1] (**0**|1|2|3|4|5|6|7|8|9)
-
-	CPU cycles are divided in core options to allow fine control of the desired CPU cycles. Setting this too low may cause slow gameplay, setting this too high might cause sound crackling and bad performance.
-
-- **CPU cycles x 1000** [dosbox_cpu_cycles_2] (**1**|2|3|4|5|6|7|8|9|0)
-
-	CPU cycles are divided in core options to allow fine control of the desired CPU cycles. Setting this too low may cause slow gameplay, setting this too high might cause sound crackling and bad performance.
-
-- **CPU cycles x 100** [dosbox_cpu_cycles_3] (**0**|1|2|3|4|5|6|7|8|9")
-
-	CPU cycles are divided in core options to allow fine control of the desired CPU cycles. Setting this too low may cause slow gameplay, setting this too high might cause sound crackling and bad performance.
+	Enable Gravis Ultrasound emulation. Settings are fixed at port 0x240, IRQ 5, DMA 3. If the ULTRADIR variable needs to be different than the default 'C:\\ULTRASND' you need to issue 'SET ULTRADIR=...' in the command line or in a batch file.
 
 ## Controls
 

--- a/docs/library/dosbox-pure.md
+++ b/docs/library/dosbox-pure.md
@@ -1,5 +1,3 @@
-![#f03c15](https://via.placeholder.com/15/f03c15/000000?text=+) (So, to create this document, I copied the [original Libretro DOSBox documentation](https://docs.libretro.com/library/dosbox/) and overwrote/expanded it. There's still many chunks of content in here that come straight from the original document and that probably need revision, and then most of the extra stuff in here comes from [Bernhard Schelling's readme for DOSBox Pure](https://github.com/schellingb/dosbox-pure). Lastly, a few additions by me. I annotated this whole thing, look for the read squares. - Matt)
-
 # DOS (DOSBox Pure)
 
 ## Background
@@ -16,14 +14,13 @@ The DOSBox core is licensed under
 - [GPLv2](https://github.com/libretro/dosbox-libretro/blob/master/COPYING)
 
 A summary of the licenses behind RetroArch and its cores can be found [here](../development/licenses.md).
-![#f03c15](https://via.placeholder.com/15/f03c15/000000?text=+) (This is a relative URL, so I'm guessing it will work correctly when this file lands on the master?)
 
 ## Extensions
 
 Content that can be loaded by the DOSBox Pure core has the following file extensions:
 
 - .zip
-- .dosz ''(alternative extension to .ZIP)''
+- .dosz _(alternative extension to .ZIP)_
 - .exe
 - .com
 - .bat
@@ -37,12 +34,11 @@ Content that can be loaded by the DOSBox Pure core has the following file extens
 - .tc
 - .m3u
 - .m3u8
-- .conf ''(bootable; booting a dosbox.conf file will mount the directory as C: and load/autoexec the conf file)''
+- .conf _(bootable; booting a dosbox.conf file will mount the directory as C: and load/autoexec the conf file)_
 
 RetroArch database(s) that are associated with the DOSBox core:
 
 - [DOS](https://github.com/libretro/libretro-database/blob/master/rdb/DOS.rdb)
-![#f03c15](https://via.placeholder.com/15/f03c15/000000?text=+) (Others?)
 
 ## Features
 !!!tip
@@ -79,7 +75,7 @@ Frontend-level settings or features that the DOSBox Pure core respects.
 
 ### MIDI playback with SoundFonts
 
-If DOSBox Pure finds one or more `.SF2` sound font files in the `system` directory of the frontend, one of them can be selected via the `Audio > MIDI SoundFont` core option. This sound font will then be used to play General Midi and Sound Canvas music.
+If DOSBox Pure finds one or more `.SF2` sound font files in the `system` directory of the frontend, one of them can be selected via the `Audio > MIDI Output` [core option](#core-options). This sound font will then be used to play `General Midi` and `Sound Canvas` music.
 
 ###  MPU-401 MIDI device emulation through MUNT
 

--- a/docs/library/dosbox-pure.md
+++ b/docs/library/dosbox-pure.md
@@ -419,7 +419,7 @@ There is also the core option `Input > Mouse Sensitivity` to increase/decrease m
 
 ### Keyboard emulation
 
-For games that don't have automated controller mappings or are not detected successfully, by default the option `Input > Bind Unused Buttons` will assign all unused buttons on the game pad with some default key.
+For games that don't have automated controller mappings or are not detected successfully, by default the option `Input > Bind Unused Buttons` will assign all unused buttons on the game pad with a respective default key.
 
 If the `Device Type` on the `Controls` screen in the RetroArch menu of any port is set to `Generic Keyboard Bindings`, all buttons will be assigned with a keyboard key.
 
@@ -450,7 +450,7 @@ If the cursor is moved above the middle of the screen, the keyboard will move to
 
 ![The DOSBox Pure gamepad mapper](https://raw.githubusercontent.com/schellingb/dosbox-pure/main/images/padmapper.png)
 
-If you need even more customization of the controls than provided by the Automated controller mappings, or the various presets for mouse, keyboard and joysticks you can use the gamepad mapper introduced in version 0.9.0 in April, 2022.
+If you need even more customization of the controls than provided by the [Automated controller mappings](#automated-controller-mappings), or the various presets for [mouse](#mouse-emulation), [keyboard](#keyboard-emulation) and [joysticks](#joystick-emulation), you can use the gamepad mapper introduced in version 0.9.0 in April, 2022.
 
 To open it, click the "PAD MAPPER" button in the On-screen keyboard (cf. above).
 

--- a/docs/library/dosbox-pure.md
+++ b/docs/library/dosbox-pure.md
@@ -4,7 +4,7 @@
 
 ## Background
 
-DOSBox Pure is fork of the multiplatform MS-DOS emulator, DOSBox. It was built by Bernhard Schelling in 2020 specifically for RetroArch/Libretro and implements advanced features like save states, an on-screen keyboard, easy controller setup or rewinding. DOSBox Pure aims for simplicity and ease of use.
+DOSBox Pure is fork of the multiplatform MS-DOS emulator, DOSBox. It was built by Psyraven in 2020 specifically for RetroArch/Libretro and implements advanced features like save states, an on-screen keyboard, easy controller setup or rewinding. DOSBox Pure aims for simplicity and ease of use.
 
 The DOSBox-Pure core has been authored by
 

--- a/docs/library/dosbox-pure.md
+++ b/docs/library/dosbox-pure.md
@@ -235,7 +235,10 @@ The DOSBox core has the following option(s) that can be tweaked from the core op
 
 Settings with (Restart) mean that core has to be closed for the new setting to be applied on next launch.
 
-### Save States Support (**Enable save states** | Enable save states with rewind | Off)
+### Save States Support
+
+[dosbox_pure_savestate]
+(**Enable save states** | Enable save states with rewind | Off)
 
 Make sure to test it in each game before using it. Complex late era DOS games might have problems. Be aware that states saved with different video, CPU or memory settings are not loadable. Rewind support comes at a high performance cost and needs at least 40MB of rewind buffer. Save states might not be compatible with new versions of this core.
 

--- a/docs/library/dosbox-pure.md
+++ b/docs/library/dosbox-pure.md
@@ -709,10 +709,12 @@ It is available any time in-game and changes are immediately saved and applied w
 ### Boppin'
 If the game rapidly cycles through the main menu options indefinitely, it has to do with malfunctioning joystick calibration. try deleting the game's config file, `BOPPIN.CFG`, and then reconfiguring the game. To do so, leave the game and from the command line, type:
 
-`CD BOPPIN
+```
+CD BOPPIN
 DEL BOPPIN.CFG
 SETUP.EXE
-BOPPIN.EXE`
+BOPPIN.EXE
+```
 
 To fix this in-game, you need to go to the core options and fiddle around with the Emulated Performance setting until the cursor stops moving.
 

--- a/docs/library/dosbox-pure.md
+++ b/docs/library/dosbox-pure.md
@@ -165,6 +165,7 @@ If the core gets loaded with a `.m3u8` file, all files listed in it will be adde
 
 You might have trouble getting stutter-free scrolling in some games (cf. https://github.com/schellingb/dosbox-pure/issues/128). There are a number of things you can try to remedy this:
 
+- In `Quick Menu > Options > Emulation Options`, set `Force 60 FPS Output` to ON.
 - In RetroArch's settings, navigate to `Video` and set `Threaded Video` to OFF.
 - Try `Video` > `Output` > `Set Display-Reported Refresh Rate`.
 - Try setting `Video` > `Synchronization` > `Vertical Sync` to ON.
@@ -199,7 +200,7 @@ This label is not saved anywhere and needs to be reapplied on every launch so it
 
 ### Keyboard layout defaults to US
 
-The keyboard layout defaults to the US Layout (QWERTY). If you need a different layout, you can change the core option `Input > Advanced > Keyboard Layout`.
+The keyboard layout defaults to the US Layout (QWERTY). If you need a different layout, you can change the core option `Input Options > Advanced > Keyboard Layout`.
 
 ### Save file handling
 
@@ -235,12 +236,38 @@ The DOSBox core has the following option(s) that can be tweaked from the core op
 
 Settings with (Restart) mean that core has to be closed for the new setting to be applied on next launch.
 
-### Save States Support
+### Manage Core Options
 
-[dosbox_pure_savestate]
-(**Enable save states** | Enable save states with rewind | Off)
+- **Reset Options**
 
-Make sure to test it in each game before using it. Complex late era DOS games might have problems. Be aware that states saved with different video, CPU or memory settings are not loadable. Rewind support comes at a high performance cost and needs at least 40MB of rewind buffer. Save states might not be compatible with new versions of this core.
+	Reset all core options to default values.
+
+### Emulation Options
+Core specific settings (latency, save states, start menu).
+
+- **Force 60 FPS Output** [dosbox_pure_force60fps] (**OFF** | ON)
+
+	Enable this to force output at 60FPS. Use this if you encounter screen tearing or vsync issues.
+	
+- **Show Performance Statistics** [dosbox_pure_perfstats] (**Disabled** | Simple | Detailed information)
+
+	Enable this to show statistics about performance and framerate and check if emulation runs at full speed.
+
+- **Save States Support** [dosbox_pure_savestate]  (**Enable save states** | Enable save states with rewind | OFF)
+
+	Make sure to test it in each game before using it. Complex late era DOS games might have problems. Be aware that states saved with different video, CPU or memory settings are not loadable. Rewind support comes at a high performance cost and needs at least 40MB of rewind buffer. Save states might not be compatible with new versions of this core.
+	
+- **Start Menu** [dosbox_pure_menu_time] (**Show at start, shut down core 5 seconds after auto started game exit** | Show at start, shut down core 3 seconds after auto started game exit | Show at start, shut down core immediately after auto started game exit | Show at start, show again after game exit (default) | Always show menu on startup and after game exit, ignore auto start setting)
+
+	Set the behavior of the start menu before and after launching a game. You can also force it to open by holding shift or L2/R2 when selecting 'Restart'.
+
+- **Advanced > Input Latency** [dosbox_pure_latency] (**Default** | Lowest latency - See CPU usage setting below! | Irregular latency - Might improve performance on low-end devices)
+
+	By default the core operates in a high performance mode with good input latency. There is a special mode available which minimizes input latency further requiring manual tweaking.
+
+- **Advanced > Low latency CPU usage** [dosbox_pure_auto_target] (**90%** | 50% > 100%)
+
+	In low latency mode when emulating DOS as fast as possible, how much time per frame should be used by the emulation. If the video is stuttering, lower this or improve render performance in the frontend (for example by disabling vsync or video processing). Use the performance statistics to easily find the maximum that still hits the emulated target framerate.
 
 ### Input Options
 
@@ -256,13 +283,114 @@ Make sure to test it in each game before using it. Complex late era DOS games mi
 
 	Bind mouse wheel up and down to two keyboard keys to be able to use it in DOS games.
 
-- **Mouse Sensitivity** [dosbox_pure_mouse_speed_factor] (**1.0** | 0.2 to 1.0 in .05 increments | 1.0 to 5.0 in .1 increments)
+- **Mouse Sensitivity** [dosbox_pure_mouse_speed_factor] (**100%** | 20% to 100% in 5% increments | 100% to 500% in 10% increments)
 
 	Sets the overall mouse cursor movement speed.
  
-- **Advanced > Horizontal Mouse Sensitivity** [dosbox_pure_mouse_speed_factor_x] (**1.0** | 0.2 to 1.0 in .05 increments | 1.0 to 5.0 in .1 increments)
+- **Advanced > Horizontal Mouse Sensitivity** [dosbox_pure_mouse_speed_factor_x] (**100%** | 20% to 100% in 5% increments | 100% to 500% in 10% increments)
 
 	Experiment with this value if the mouse is too fast/slow when moving left/right.
+
+- **Advanced > Use Mouse Input** [dosbox_pure_mouse_input] (**ON** | OFF)
+
+	You can disable input handling from a mouse or a touchscreen (emulated mouse through joypad will still work).
+
+- **Advanced > Automatic Game Pad Mappings** [dosbox_pure_auto_mapping] (**On (default)** | Enable with notification on game detection | Off)
+
+	DOSBox Pure can automatically apply a gamepad control mapping scheme when it detects a game. These button mappings are provided by the Keyb2Joypad Project (by Jemy Murphy and bigjim).
+
+- **Advanced > Keyboard Layout** [dosbox_pure_keyboard_layout] (**US (default)** | UK | Belgium | Brazil | Croatia | Czech Republic | Denmark | Finland | France | Germany | Greece | Hungary | Iceland | Italy | Netherlands | Norway | Poland | Portugal | Russia | Slovakia | Slovenia | Spain | Sweden | Switzerland (German) | Switzerland (French) | Turkey)
+
+	Select the keyboard layout (will not change the On Screen Keyboard).
+
+- **Advanced > Joystick Analog Deadzone** [dosbox_pure_joystick_analog_deadzone] (**15%** | 0% to 35% in 5% increments)
+
+	Set the deadzone of the joystick analog sticks. May be used to eliminate drift caused by poorly calibrated joystick hardware.
+
+- **Advanced > Enable Joystick Timed Intervals** [dosbox_pure_joystick_timed] (**On (default)** | Off)
+
+	Enable timed intervals for joystick axes. Experiment with this option if your joystick drifts.
+
+### Performance Options
+
+- **Emulated Performance** [dosbox_pure_cycles] (**AUTO - DOSBox will try to detect performance needs (default)** | MAX - Emulate as many instructions as possible | 8086/8088, 4.77 MHz from 1980 (315 cps) | 286, 6 MHz from 1982 (1320 cps) | 286, 12.5 MHz from 1985 (2750 cps) | 386, 20 MHz from 1987 (4720 cps) |  | 386DX, 33 MHz from 1989 (7800 cps) | 486DX, 33 MHz from 1990 (13400 cps) | 486DX2, 66 MHz from 1992 (26800 cps) | Pentium, 100 MHz from 1995 (77000 cps) | Pentium II, 300 MHz from 1997 (200000 cps) | Pentium III, 600 MHz from 1999 (500000 cps) | AMD Athlon, 1.2 GHz from 2000 (1000000 cps))
+
+	The raw performance that DOSBox will try to emulate.
+
+- **Detailed > Performance Scale** [dosbox_pure_cycles_scale] (**100%** | 20% to 200% in 5% increments)
+
+	Fine tune the emulated performance for specific needs.
+
+### Video Options
+
+- **** [] (**** |  |  |  |)
+
+
+
+- **** [] (**** |  |  |  |)
+
+
+
+- **** [] (**** |  |  |  |)
+
+
+
+- **** [] (**** |  |  |  |)
+
+
+- **** [] (**** |  |  |  |)
+
+
+- **** [] (**** |  |  |  |)
+
+
+
+- **** [] (**** |  |  |  |)
+
+
+
+- **** [] (**** |  |  |  |)
+
+
+
+
+
+- **** [] (**** |  |  |  |)
+
+
+
+
+- **** [] (**** |  |  |  |)
+
+
+
+
+- **** [] (**** |  |  |  |)
+
+
+- **** [] (**** |  |  |  |)
+
+
+- **** [] (**** |  |  |  |)
+
+
+- **** [] (**** |  |  |  |)
+
+
+- **** [] (**** |  |  |  |)
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 
 ================================================

--- a/docs/library/dosbox-pure.md
+++ b/docs/library/dosbox-pure.md
@@ -142,6 +142,12 @@ If there is only a single executable, the menu will not show and directly run th
 
 To force the menu to be shown, hold shift on the keyboard or L2 or R2 on the gamepad while selecting `Restart` in the core menu.
 
+### Directly run PC booter games from the start menu
+
+![Directly run PC booter games from the start menu](https://user-images.githubusercontent.com/14200249/164041304-f921c806-8790-4bee-b9fa-5826714012e3.gif)
+
+In addition, there's support for swapping floppy disk images (or PCjr cartridges) at runtime via a frontend's Disc Control menu and hotkeys.
+
 ### Installing CD-ROM games from disc images (ISO etc.) and running them
 
 In order to install a game from a CD-ROM image (e.g., a .iso file), use the "Load Content" option in the RetroArch main menu. Navigate to the ISO and launch it with the DOSBox Pure core.

--- a/docs/library/dosbox-pure.md
+++ b/docs/library/dosbox-pure.md
@@ -160,6 +160,8 @@ See screenshot in "Start menu with auto start" section above for reference.
 
 ![Directly run PC booter games from the start menu](https://user-images.githubusercontent.com/14200249/164041304-f921c806-8790-4bee-b9fa-5826714012e3.gif)
 
+There's also support for swapping floppy disk images (or PCjr cartridges) at runtime via a frontend's Disc Control menu and hotkeys.
+
 ### Loading M3U8 files
 
 If the core gets loaded with a `.m3u8` file, all files listed in it will be added to the disc swap menu. The first image will automatically get mounted as the A: or D: drive depending on whether it is a CD or floppy disk image.

--- a/docs/library/dosbox-pure.md
+++ b/docs/library/dosbox-pure.md
@@ -4,7 +4,7 @@
 
 ## Background
 
-DOSBox Pure is fork of the multiplatform MS-DOS emulator, DOSBox. It was built by Psyraven in 2020 specifically for RetroArch/Libretro and implements advanced features like save states, an on-screen keyboard, easy controller setup or rewinding. DOSBox Pure aims for simplicity and ease of use.
+DOSBox Pure is fork of the multiplatform MS-DOS emulator, DOSBox. It was built by Psyraven in 2020 specifically for RetroArch/Libretro and implements advanced features like save states, an on-screen keyboard, highly customizable controller setup or rewinding. DOSBox Pure aims for simplicity and ease of use.
 
 The DOSBox-Pure core has been authored by
 

--- a/docs/library/dosbox-pure.md
+++ b/docs/library/dosbox-pure.md
@@ -707,10 +707,9 @@ It is available any time in-game and changes are immediately saved and applied w
 ## Compatibility
 
 ### Boppin'
-If the game rapidly cycles through the main menu options indefinitely, it has to do with malfunctioning joystick calibration. try deleting the game's config file, `BOPPIN.CFG`, and then reconfiguring the game. To do so, leave the game and from the command line, type:
+If the game rapidly cycles through the main menu options indefinitely, it has to do with malfunctioning joystick calibration. try deleting the game's config file, `BOPPIN.CFG`, and then reconfiguring the game. To do so, go to the command line from the start menu, then type:
 
 ```
-CD BOPPIN
 DEL BOPPIN.CFG
 SETUP.EXE
 BOPPIN.EXE

--- a/docs/library/dosbox-pure.md
+++ b/docs/library/dosbox-pure.md
@@ -54,12 +54,12 @@ Frontend-level settings or features that the DOSBox Pure core respects.
 | States            | ✔         |
 | [Rewind](#rewind-support)            | ✔         |
 | Netplay           | ✕         |
-| Core Options      | ✔         |
+| [Core Options](#core-options)      | ✔         |
 | RetroAchievements | ✕         |
-| RetroArch Cheats  | ✔         |
-| Native Cheats     | ✔         |
-| Controls          | ✔         |
-| Remapping         | ✔         |
+| [RetroArch Cheats](#cheats-support)  | ✔         |
+| [Native Cheats](#cheats-support)     | ✔         |
+| [Controls](#controls)          | ✔         |
+| [Remapping](#gamepad-mapper)         | ✔         |
 | Multi-Mouse       | ✕         |
 | Rumble            | ✕         |
 | Sensors           | ✕         |
@@ -230,6 +230,14 @@ Settings with (Restart) mean that core has to be closed for the new setting to b
 ### Manage Core Options
 Save or remove option overrides for the current content.
 
+- **Save game options**
+
+	Saves current options specifically for running game.
+
+- **Save Content Directory Options**
+
+	Saves current options specifically for running game's content directory.
+
 - **Reset Options**
 
 	Reset all core options to default values.
@@ -356,7 +364,7 @@ Other system settings for emulated RAM and CPU.
 	486 (slow): Betrayal in Antara
 	Pentium (slow): Fifa International Soccer 1994, Windows 95/Windows 3.x games
 
-- **Advanced > CPU Core (restart required)** [dosbox_pure_cpu_core] (**Auto - Real-mode games use normal, protected-mode games use dynamic** | Dynamic - Dynamic recompilation (fast, using dynamic_x86 implementation) | Auto - Real-mode games use normal, protected-mode games use dynamic | Dynamic - Dynamic recompilation (fast, using dynrec implementation) | **Normal (interpreter)** | Simple (interpreter optimized for old real-mode games))
+- **Advanced > CPU Core** [dosbox_pure_cpu_core] (**Auto - Real-mode games use normal, protected-mode games use dynamic** | Dynamic - Dynamic recompilation (fast, using dynamic_x86 implementation) | Auto - Real-mode games use normal, protected-mode games use dynamic | Dynamic - Dynamic recompilation (fast, using dynrec implementation) | **Normal (interpreter)** | Simple (interpreter optimized for old real-mode games))
 
 	Emulation method (DOSBox CPU core) used.
 

--- a/docs/library/dosbox-pure.md
+++ b/docs/library/dosbox-pure.md
@@ -4,7 +4,7 @@
 
 ## Background
 
-DOSBox Pure is fork of the multiplatform MS-DOS emulator, DOSBox. It was built by Psyraven in 2020 specifically for RetroArch/Libretro and implements advanced features like save states, an on-screen keyboard, highly customizable controller setup or rewinding. DOSBox Pure aims for simplicity and ease of use.
+DOSBox Pure is a fork of the multiplatform MS-DOS emulator, DOSBox. It was built by Psyraven in 2020 specifically for RetroArch/Libretro and implements advanced features like save states, an on-screen keyboard, highly customizable controller setup or rewinding. DOSBox Pure aims for simplicity and ease of use.
 
 The DOSBox-Pure core has been authored by
 
@@ -23,7 +23,7 @@ A summary of the licenses behind RetroArch and its cores can be found [here](../
 Content that can be loaded by the DOSBox Pure core has the following file extensions:
 
 - .zip
-- .dosz (alternative extension to .ZIP)
+- .dosz ''(alternative extension to .ZIP)''
 - .exe
 - .com
 - .bat
@@ -33,8 +33,11 @@ Content that can be loaded by the DOSBox Pure core has the following file extens
 - .img
 - .ima
 - .vhd
+- .jrc
+- .tc
 - .m3u
 - .m3u8
+- .conf ''(bootable; booting a dosbox.conf file will mount the directory as C: and load/autoexec the conf file)''
 
 RetroArch database(s) that are associated with the DOSBox core:
 
@@ -94,15 +97,11 @@ For details how to use it and how to find new cheats while playing the game, che
 
 The DOSBox Pure core fully supports libretro save states. Make sure to test it in each game before using it. Complex late era DOS games might have problems.
 
-Be aware that states saved with different video or cpu settings are not loadable. Also, save states might not be compatible across different versions of DOSBox Pure.
+Be aware that states saved with different video or cpu settings are not loadable.
 
 ### Rewind support
 
 Using the core option `Save States Support`, rewinding can be enabled. Keep in mind that rewind support comes at a high performance cost.
-
-## Directories
-
-The DOSBox Pure core's library name is 'DOSBox-Pure'.
 
 ## Geometry and timing
 
@@ -116,7 +115,7 @@ The DOSBox Pure core's library name is 'DOSBox-Pure'.
 
 ## Loading content
 
-### loading of dosbox.conf files
+### Loading of dosbox.conf files
 
 DOSBox Pure can boot directly from a .conf file or it will load C:\DOSBOX.CONF automatically if it exists in the mounted ZIP or path.
 
@@ -161,6 +160,8 @@ See screenshot in "Start menu with auto start" section above for reference.
 ### Directly run PC booter games from the start menu
 
 ![Directly run PC booter games from the start menu](https://user-images.githubusercontent.com/14200249/164041304-f921c806-8790-4bee-b9fa-5826714012e3.gif)
+
+When loading a ZIP file which contains a floppy or hard-disk image or loading such a disk image directly, the start menu will show an additional option `[BOOT IMAGE FILE]`. When selected, a list of system modes (emulated graphics card) will be shown and once a mode is selected, DOSBox Pure will try to boot from the mounted image. While running a booter game, the mounted disk can be easily swapped with the Disc Control menu or hotkeys set in the frontend.
 
 There's also support for swapping floppy disk images (or PCjr cartridges) at runtime via a frontend's Disc Control menu and hotkeys.
 
@@ -220,18 +221,6 @@ When modifications to the file system loaded from a ZIP file happen, these modif
 - The larger the save, the less often it will be written out.
 - Up to 1MB of total save data, it will be written out 2 seconds after the previous file modification. Then gradually until at max 59MB and more, it will be written out 60 seconds after the last file modification.
 
-## Features currently not implemented
-
-### Store ZIP seek index into save file
-
-When a DOS game opens a large file and wants to read some data from near the end of the file, DOSBox Pure needs to decompress the entire file to do that. This can be most noticeable when mounting CD-ROM images from inside ZIP files.
-Afterwards there is an index buffer which will be used to decompress random locations of the file and file access will be much faster.
-This index buffer should be stored into the game save file to avoid having to slowly rebuild it every time the same game is launched.
-
-### Serial Port, IPX emulation
-
-For now, serial port and IPX emulation from base DOSBox have been removed.
-
 ## Core options
 
 The DOSBox core has the following options that can be tweaked from the core options menu. The default setting is bolded.
@@ -258,7 +247,7 @@ Core specific settings (latency, save states, start menu).
 
 - **Save States Support** [dosbox_pure_savestate]  (**Enable save states** | Enable save states with rewind | OFF)
 
-	Make sure to test it in each game before using it. Complex late era DOS games might have problems. Be aware that states saved with different video, CPU or memory settings are not loadable. Rewind support comes at a high performance cost and needs at least 40MB of rewind buffer. Save states might not be compatible with new versions of this core.
+	Make sure to test it in each game before using it. Complex late era DOS games might have problems. Be aware that states saved with different video, CPU or memory settings are not loadable. Rewind support comes at a high performance cost and needs at least 40MB of rewind buffer.
 	
 - **Start Menu** [dosbox_pure_menu_time] (**Show at start, shut down core 5 seconds after auto started game exit** | Show at start, shut down core 3 seconds after auto started game exit | Show at start, shut down core immediately after auto started game exit | Show at start, show again after game exit (default) | Always show menu on startup and after game exit, ignore auto start setting)
 


### PR DESCRIPTION
Hello, Libretro team! Over the past one and a half years, I and @schellingb have been working on a documentation for the core, DOSBox Pure. Today, it's finally done and we hope you will consider adding it to the Libretro Docs library (https://docs.libretro.com/) in _For Users_ > _Core Library: Emulation_ > _DOS Emulation_.

I hope this is the correct way to do this. I see a message at the top here saying, "Can’t automatically merge. Don’t worry, you can still create the pull request." The file I'm submitting is [dosbox-pure.md](https://github.com/mrmatteastwood/docs/blob/DOSBox-Pure-doc-WIP/docs/library/dosbox-pure.md). Let me know if there's anything else you need.