### PR TITLE
Update stella.md

### DIFF
--- a/docs/library/stella.md
+++ b/docs/library/stella.md
@@ -27,6 +27,7 @@ Content that can be loaded by the Stella core have the following file extensions
 
 - .a26
 - .bin
+- .zip
 
 ## Databases
 


### PR DESCRIPTION
.zip files extract fine for me in 1.10.3 steam deck install. Other docs include archive extenstions as allowed input, but maybe someone wants to take a stance here and say if it should be documented as an allowed extention or just say elsewhere that .{archive} can be used for the accepted file formats. 