### PR TITLE
Remove 'firmware.bin' MD5 for DeSmuME and melonDS, make BIOS/firmware optional for melonDS

### DIFF
--- a/docs/library/desmume.md
+++ b/docs/library/desmume.md
@@ -42,9 +42,9 @@ The md5sum of firmware.bin will vary from dump to dump. bios7 and bios9 should b
 
 |   Filename   |    Description          |              md5sum              |
 |:------------:|:-----------------------:|:--------------------------------:|
-| firmware.bin | NDS Firmware - Optional | 145eaef5bd3037cbc247c213bb3da1b3 |
 | bios7.bin    | ARM7 BIOS - Optional    | df692a80a5b1bc90728bc3dfc76cd948 |
 | bios9.bin    | ARM9 BIOS - Optional    | a392174eb3e572fed6447e956bde4b25 |
+| firmware.bin | NDS Firmware - Optional |                                  |
 
 ## Features
 

--- a/docs/library/melonds.md
+++ b/docs/library/melonds.md
@@ -36,9 +36,9 @@ Required or optional firmware files go in the frontend's system directory.
 
 |   Filename       |    Description           |              md5sum              |
 |:----------------:|:------------------------:|:--------------------------------:|
-| bios7.bin        | NDS ARM7 BIOS - Required | df692a80a5b1bc90728bc3dfc76cd948 |
-| bios9.bin        | NDS ARM9 BIOS - Required | a392174eb3e572fed6447e956bde4b25 |
-| firmware.bin     | NDS Firmware - Required  | 145eaef5bd3037cbc247c213bb3da1b3 |
+| bios7.bin        | NDS ARM7 BIOS - Optional | df692a80a5b1bc90728bc3dfc76cd948 |
+| bios9.bin        | NDS ARM9 BIOS - Optional | a392174eb3e572fed6447e956bde4b25 |
+| firmware.bin     | NDS Firmware - Optional  |                                  |
 | dsi_bios7.bin    | DSi ARM7 BIOS - Optional |                                  |
 | dsi_bios9.bin    | DSi ARM9 BIOS - Optional |                                  |
 | dsi_firmware.bin | DSi Firmware - Optional  |                                  |


### PR DESCRIPTION
MD5 varies with the DS settings (language, username, etc.) so it doesn't make sense to mention a specific MD5 and might confuse the users.

**edit:** Also changed BIOS/firmware files to "optional" for melonDS.