### PR TITLE
add back the 'Edit' link

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -455,6 +455,7 @@ theme:
     - navigation.top
     - tables
     - content.code.annotate
+    - content.action.edit
   font:
     text: Roboto
     code: Roboto Mono


### PR DESCRIPTION
The edit link is now enabled with a feature flag in Mkdocs Material 9.x, this commit makes it visible again.