### PR TITLE
Update docs to state the correct license for QuickNES core

### DIFF
--- a/docs/development/licenses.md
+++ b/docs/development/licenses.md
@@ -171,7 +171,7 @@ See below for a summary of the licenses behind RetroArch and its cores:
 | [PrBoom](../library/prboom.md)                                                   | [GPLv2](https://github.com/libretro/libretro-prboom/blob/master/COPYING)                  |                |
 | [ProSystem](..//library/prosystem.md)                                            | [GPLv2](https://github.com/libretro/prosystem-libretro/blob/master/License.txt)           |                |
 | PX68k                                                                            | [kero_src.txt](https://github.com/libretro/px68k-libretro/blob/master/doc/kero_src.txt)   |                |                                                                                          |                |
-| [QuickNES](../library/quicknes.md)                                               | [LGPLv2.1+](https://github.com/kode54/QuickNES/blob/master/COPYING)                       |                |
+| [QuickNES](../library/quicknes.md)                                               | [GPLv2](https://github.com/kode54/QuickNES/blob/master/COPYING)                       |                |
 | [Redream (libretro fork)](../library/redream.md)                                 | [GPLv3](https://github.com/libretro/redream/blob/master/LICENSE.txt)                      |                |
 | [REminiscence](../library/reminiscence.md)                                       | GPLv3                                                                                     |                |
 | RemoteJoy                                                                        | [GPLv2](https://github.com/libretro/libretro-remotejoy/blob/master/LICENSE)               |                |

--- a/docs/library/quicknes.md
+++ b/docs/library/quicknes.md
@@ -11,7 +11,7 @@ The QuickNES core has been authored by
 
 The QuickNES core is licensed under
 
-- [LGPLv2.1+](https://github.com/kode54/QuickNES/blob/master/COPYING)
+- [GPLv2](https://github.com/kode54/QuickNES/blob/master/COPYING)
 
 A summary of the licenses behind RetroArch and its cores can be found [here](../development/licenses.md).
 


### PR DESCRIPTION
The documentation stated that the QuickNES core was licensed as LGPLv2.1+ when it appears to be licensed as GPLv2.