### PR TITLE
Update build-ios.md instructions to indicate the _Metal project

### DIFF
--- a/docs/guides/build-ios.md
+++ b/docs/guides/build-ios.md
@@ -33,7 +33,7 @@ Unzip the above archive of cores into the following directory in the RetroArch p
 
 ### Open RetroArch in Xcode
 
-Open the Xcode project located at `pkg/apple/iOS/RetroArch_iOS11.xcodeproj`
+Open the Xcode project located at `pkg/apple/iOS/RetroArch_iOS11_Metal.xcodeproj`.
 
 ### Sign in with your Apple ID
 


### PR DESCRIPTION
It seems the `RetroArch_iOS11_Metal` project is better-supported (the non-Metal one the docs currently recommend doesn't even build, it's missing the CoreHaptics.framework import in the .xcproj), and has better performance.

Unless there's some reason I'm missing to prefer redirecting users to the old non-Metal build?