### PR TITLE
gpsp - Phantasy Star fix

### DIFF
--- a/docs/library/gpsp.md
+++ b/docs/library/gpsp.md
@@ -131,7 +131,7 @@ The gpSP core supports the following device type(s) in the controls menu, bolded
 | Harry Potter - Quidditch World Cup  |Crashes when going ingame.       |
 | Koro Koro Puzzle Happy Panechu!     |The tilt sensor is not emulated. |
 | ~~Mario & Luigi - Superstar Saga~~      |~~Crashes when entering a battle.~~  |
-| Phantasy Star Collection            |Phantasy Star 1 flickers.        |
+| Phantasy Star Collection            |Phantasy Star 1 flickers - turn on Interframe Blending in core options to fix.|
 | ~~R-Type III - The Third Lightning~~    |~~Softlocks at Irem startup screen.~~|
 | ~~Rock 'n Roll Racing~~                 |~~Corrupted graphics, not playable.~~|
 | ~~Rockman & Forte~~                     |~~Doesn't continue after GBA BIOS screen.~~|


### PR DESCRIPTION
Turning on Interframe Blending in the core options fixes the flickering on this game.