### PR TITLE
Fix Xcode typos

### DIFF
--- a/docs/development/retroarch/compilation/ios.md
+++ b/docs/development/retroarch/compilation/ios.md
@@ -13,7 +13,7 @@ Because iOS requires that all code be signed, iOS does not support installing/up
 
 The following software needs to be installed:
 
-- XCode (macOS only)
+- Xcode (macOS only)
 
 You can get Xcode from the Mac App Store.
 

--- a/docs/guides/building-ludo.md
+++ b/docs/guides/building-ludo.md
@@ -56,7 +56,7 @@ go build
 
 ### Mac OS X
 
-First setup [XCode](https://developer.apple.com/documentation/xcode/) then setup [Homebrew](https://brew.sh/).
+First setup [Xcode](https://developer.apple.com/documentation/xcode/) then setup [Homebrew](https://brew.sh/).
 
 ```brew
 brew install go openal-soft


### PR DESCRIPTION
# Rationale

The correct spelling of Xcode is without a capital "c". See https://developer.apple.com/xcode/ for reference.