### PR TITLE
Add MicroW8 libretro core

### DIFF
--- a/docs/development/licenses.md
+++ b/docs/development/licenses.md
@@ -97,6 +97,7 @@ See below for a summary of the licenses behind RetroArch and its cores:
 | EasyRPG                                                                          | [GPLv3](https://github.com/libretro/easyrpg-libretro/blob/master/COPYING)                 |                |
 | [EightyOne](../library/eightyone.md)             			           | [GPLv3](https://github.com/libretro/81-libretro/blob/master/LICENSE)                      |                |
 | [Elektronika - BK-0010/BK-0011](../library/bk.md)                                          | [BSD](https://github.com/libretro/bk-emulator/blob/master/COPYING) |                            |
+| [EmuSCV](../library/emuscv.md)                           | [GPLv2](https://github.com/libretro/)                  |                |
 | [Emux CHIP-8](../library/emux_chip8.md)                                          | [GPLv2](https://github.com/libretro/emux/blob/master/COPYING)                             |                |
 | [Emux GB](../library/emux_gb.md)                                                 | [GPLv2](https://github.com/libretro/emux/blob/master/COPYING)                             |                |
 | [Emux NES](../library/emux_nes.md)                                               | [GPLv2](https://github.com/libretro/emux/blob/master/COPYING)                             |                |
@@ -146,6 +147,7 @@ See below for a summary of the licenses behind RetroArch and its cores:
 | MESS 2014                                                 		               | [MAME (Non-commercial)](https://github.com/libretro/mame2014-libretro/blob/master/docs/license.txt)         | Non-commercial |
 | [Meteor](../library/meteor.md)                            		           | [GPLv3](https://github.com/libretro/meteor-libretro/blob/master/COPYING)                  |                |
 | [mGBA](../library/mgba.md)                                                       | [MPLv2.0](https://github.com/libretro/mgba/blob/master/LICENSE)                           |                |
+| [MicroW8](../library/microw8.md)                                                       | [Unlicense](https://github.com/libretro/uw8-libretro/blob/main/UNLICENSE)                           |                |
 | mpv                                                                              | [GPLv3](https://github.com/libretro/libretro-mpv/blob/master/LICENSE)                     |                |
 | [Mr.Boom](../library/mr_boom.md)                          		           | [MIT](https://github.com/libretro/mrboom-libretro/blob/master/LICENSE)                    |                |
 | Mupen64Plus                                               		           | [GPLv3](https://github.com/libretro/mupen64plus-libretro/blob/master/LICENSE)             |                |
@@ -194,7 +196,6 @@ See below for a summary of the licenses behind RetroArch and its cores:
 | [TyrQuake](../library/tyrquake.md)                                               | [GPLv2](https://github.com/libretro/tyrquake/blob/master/gnu.txt)                         |                |
 | UME 2014                                                                         | [MAME (Non-commercial)](https://github.com/libretro/mame2014-libretro/blob/master/docs/license.txt)         | Non-commercial |
 | [Uzem](../library/uzem.md)                                                       | [GPLv3](https://github.com/Uzebox/uzebox/blob/master/gpl-3.0.txt)                         |                |
-| [EmuSCV](../library/emuscv.md)						   | [GPLv2](https://github.com/libretro/)                  |                |
 | [VaporSpec](../library/vaporspec.md)                                             | [MIT](https://github.com/minkcv/vm/blob/master/LICENSE.md)    
 | [VBA-M](../library/vba_m.md)                                                     | [GPLv2](https://github.com/libretro/vbam-libretro/blob/master/doc/gpl.txt)                |                |
 | [VBA Next](../library/vba_next.md)                                               | [GPLv2](https://github.com/libretro/vba-next/blob/master/LICENSE)                         |                |

--- a/docs/library/microw8.md
+++ b/docs/library/microw8.md
@@ -1,0 +1,97 @@
+# MicroW8
+
+## Background
+
+- MicroW8 is a WebAssembly based fantasy console usable for size-coding or larger games.
+
+The MicroW8 core has been authored by
+
+- [Dennis Ranke](https://github.com/exoticorn)
+- [Kivutar](https://github.com/kivutar)
+
+
+The MicroW8 core is licensed under
+
+- [Unlicense](https://github.com/libretro/uw8-libretro/blob/main/UNLICENSE)
+
+A summary of the licenses behind RetroArch and its cores can be found [here](../development/licenses.md).
+
+## Extensions
+
+Content that can be loaded by the MicroW8 core have the following file extensions:
+
+- .uw8
+- .wasm
+
+RetroArch database(s) that are associated with the MicroW8 core:
+
+- [MicroW8](https://github.com/libretro/libretro-database/blob/master/rdb/MicroW8.rdb)
+
+## Features
+
+Frontend-level settings or features that the MicroW8 core respects.
+
+| Feature           | Supported |
+|-------------------|:---------:|
+| Restart           | ✔         |
+| Saves             | ✕         |
+| States            | ✔         |
+| Rewind            | ✔         |
+| Netplay           | ✔         |
+| Core Options      | ✕         |
+| RetroAchievements | ✕         |
+| RetroArch Cheats  | ✕         |
+| Native Cheats     | ✕         |
+| Controls          | ✔         |
+| Remapping         | ✔         |
+| Multi-Mouse       | ✕         |
+| Rumble            | ✕         |
+| Sensors           | ✕         |
+| Camera            | ✕         |
+| Location          | ✕         |
+| Subsystem         | ✕         |
+| [Softpatching](../guides/softpatching.md) | ✕         |
+| Disk Control      | ✕         |
+| Username          | ✕         |
+| Language          | ✕         |
+| Crop Overscan     | ✕         |
+| LEDs              | ✕         |
+
+## Geometry and timing
+
+- The MicroW8 core's core provided FPS is 60.
+- The MicroW8 core's core provided sample rate is 44100.
+- The MicroW8 core's base width is 320.
+- The MicroW8 core's base height is 240.
+- The MicroW8 core's max width is 320.
+- The MicroW8 core's max height is 240.
+- The MicroW8 core's core provided aspect ratio is 4/3.
+
+## User 1 device types
+
+The MicroW8 core supports the following device type(s) in the controls menu, bolded device types are the default for the specified user(s):
+
+- None - Doesn't disable input.
+- **RetroPad**
+
+
+## Joypad
+
+| RetroPad Inputs                                | MicroW8 inputs           |
+|------------------------------------------------|--------------------------|
+| ![](../image/retropad/retro_dpad_up.png)       | D-Pad Up                 |
+| ![](../image/retropad/retro_dpad_down.png)     | D-Pad Down               |
+| ![](../image/retropad/retro_dpad_left.png)     | D-Pad Left               |
+| ![](../image/retropad/retro_dpad_right.png)    | D-Pad Right              |
+| ![](../image/retropad/retro_x.png)             | Button X                 |
+| ![](../image/retropad/retro_y.png)             | Button Y                 |
+| ![](../image/retropad/retro_a.png)             | Button A                 |
+| ![](../image/retropad/retro_b.png)             | Button B                 |
+
+## External Links
+
+- [Official Website](https://exoticorn.github.io/microw8)
+- [Libretro MicroW8 core info file](https://github.com/libretro/libretro-super/blob/master/dist/info/uw8_libretro.info)
+- [Libretro MicroW8 repository](https://github.com/libretro/uw8-libretro)
+- [Report Libretro MicroW8 core issues here](https://github.com/libretro/uw8-libretro/issues)
+- [MicroW8 games](https://itch.io/games/tag-microw8)

--- a/docs/meta/core-list.md
+++ b/docs/meta/core-list.md
@@ -122,6 +122,7 @@
 | MESS 2015                 | Multi (various)        | (See MAME note)    |
 | Meteor                    | Game Boy Advance       |                    |
 | mGBA                      | Game Boy Advance       |                    |
+| Microw8                   | Game engine            | A port of a WebAssembly based fantasy console to libretro |
 | Minivmac                  | Mac II                 | MacII variant of minivmac emulator |
 | mpv                       | Media player           | An port of MPV media player to libretro |
 | Mr.Boom                   | Game                   | A clone of the classic Bomberman series |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -264,6 +264,7 @@ nav:
       - 'Jump n Bump': 'library/jumpnbump.md'
       - 'LowRes NX': 'library/lowres_nx.md'      
       - 'Lua Engine (Lutro)': 'library/lutro.md'
+      - 'MicroW8': 'library/microw8.md'
       - 'Minecraft (Craft)': 'library/craft.md'
       - 'Mr.Boom (Bomberman)': 'library/mr_boom.md'
       - 'Quake 1 (TyrQuake)': 'library/tyrquake.md'


### PR DESCRIPTION
### Informations
[Libretro core](https://github.com/libretro/uw8-libretro)
[Info](https://github.com/libretro/libretro-super/blob/master/dist/info/uw8_libretro.info)
[DB](https://github.com/libretro/libretro-database/blob/master/rdb/MicroW8.rdb)