### PR TITLE
Update package list for switch-libnx.md

### DIFF
--- a/docs/development/retroarch/compilation/switch-libnx.md
+++ b/docs/development/retroarch/compilation/switch-libnx.md
@@ -9,7 +9,7 @@ Then, install all the required libraries:
     - replace `dkp-pacman` by `pacman` on Linux and Mac OS
 
 ```
-dkp-pacman -Sy devkit-env devkitA64 libnx switch-tools switch-mesa switch-zlib switch-bzip2 switch-freetype switch-libpng
+dkp-pacman -Sy devkit-env devkitA64 libnx switch-tools switch-mesa switch-zlib switch-bzip2 switch-liblzma switch-freetype switch-libpng switch-libvpx switch-libffmpeg
 ```
 
 ## RetroArch Compilation


### PR DESCRIPTION
Trying to follow switch-libnx build instructions with an up-to-date devkitpro toolchain resulted in the linker failing to find many libraries. Whereas the Makefile is correct and up-to-date relative to the SDK, this documentation page apparently still reported an old list of required packages, which would be now incomplete. Simply installing 3 additional packages fixes the build issue.