### PR TITLE
Correct Vircon32 vertical resolution

### DIFF
--- a/docs/library/vircon32.md
+++ b/docs/library/vircon32.md
@@ -75,9 +75,9 @@ Frontend-level settings or features that the Vircon32 core respects.
 - The Vircon32 core's core provided FPS is 60.
 - The Vircon32 core's core provided sample rate is 44100.
 - The Vircon32 core's base width is 640.
-- The Vircon32 core's base height is 480.
+- The Vircon32 core's base height is 360.
 - The Vircon32 core's max width is 640.
-- The Vircon32 core's max height is 480.
+- The Vircon32 core's max height is 360.
 - The Vircon32 core's core provided aspect ratio is 16/9.
 
 ## User 1 - 4 device types


### PR DESCRIPTION
This PR only corrects the wrong resolution listed for Vircon32. It is not 640x480, but 640x360 (hence the 16:9 ratio).