### PR TITLE
Update cli-intro.md

### DIFF
--- a/docs/guides/cli-intro.md
+++ b/docs/guides/cli-intro.md
@@ -4,7 +4,7 @@ RetroArch can be used from its robust graphical interfaces as well as a powerful
 
 Note: please be aware of whether your system uses DOS/Windows style paths with backslashes `\` or Unix-style paths with forward slashes: `/`.
 
-Some cores like [ScummVM](https://docs.libretro.com/library/scummvm/) (which also has an inbuilt GUI file browser), do not require any content in order to work. This is determined by the core info files with the line `supports_no_game = "true"`. In this case, after you have loaded the core, 'Start Core' will appear inside the main menu. Select this to start the core directly.
+Some cores like [ScummVM](https://docs.libretro.com/library/scummvm/) (which also has an inbuilt GUI file browser), do not require any content file name passed as a command line argument. This is determined by the core info files with the line `supports_no_game = "true"`. In this case, after you have loaded the core, 'Start Core' will appear inside the main menu. Select this to start the core directly.
 
 <iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/W-fRcamSp-c" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 

--- a/docs/guides/cli-intro.md
+++ b/docs/guides/cli-intro.md
@@ -4,7 +4,7 @@ RetroArch can be used from its robust graphical interfaces as well as a powerful
 
 Note: please be aware of whether your system uses DOS/Windows style paths with backslashes `\` or Unix-style paths with forward slashes: `/`.
 
-Some cores don't require a content filename passed as a command line argument, for example [ScummVM](https://docs.libretro.com/library/scummvm/), which has an inbuilt file browser.
+Some cores like [ScummVM](https://docs.libretro.com/library/scummvm/) (which also has an inbuilt GUI file browser), do not require any content in order to work. This is determined by the core info files with the line `supports_no_game = "true"`. In this case, after you have loaded the core, 'Start Core' will appear inside the main menu. Select this to start the core directly.
 
 <iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/W-fRcamSp-c" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 

--- a/docs/guides/cli-intro.md
+++ b/docs/guides/cli-intro.md
@@ -4,7 +4,7 @@ RetroArch can be used from its robust graphical interfaces as well as a powerful
 
 Note: please be aware of whether your system uses DOS/Windows style paths with backslashes `\` or Unix-style paths with forward slashes: `/`.
 
-Some cores like [ScummVM](https://docs.libretro.com/library/scummvm/) (which also has an inbuilt GUI file browser), do not require any content file name passed as a command line argument. This is determined by the core info files with the line `supports_no_game = "true"`. In this case, after you have loaded the core, 'Start Core' will appear inside the main menu. Select this to start the core directly.
+Some cores like [ScummVM](https://docs.libretro.com/library/scummvm/) (which also has an inbuilt GUI file browser), do not require any content file name passed as a command line argument. This is determined by the core info files with the line `supports_no_game = "true"`. In this case, after you have loaded the core and if it is not starting directly, select 'Start Core' that will appear inside the main menu.
 
 <iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/W-fRcamSp-c" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 

--- a/docs/guides/cli-intro.md
+++ b/docs/guides/cli-intro.md
@@ -4,6 +4,8 @@ RetroArch can be used from its robust graphical interfaces as well as a powerful
 
 Note: please be aware of whether your system uses DOS/Windows style paths with backslashes `\` or Unix-style paths with forward slashes: `/`.
 
+Some cores don't require a content filename passed as a command line argument, for example [ScummVM](https://docs.libretro.com/library/scummvm/), which has an inbuilt file browser.
+
 <iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/W-fRcamSp-c" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 #### On macOS: invoking the RetroArch CLI executable


### PR DESCRIPTION
Documented `supports_no_game = "true"` etc to make it more convenient to use the CLI by not being force to pass a content file name argument.


# Direct load
Original text that I copy/pasted from https://www.retroarch.com/?page=cores: `In this case, after you have loaded the core, 'Start Core' will appear inside the main menu. Select this to start the core directly.`

However, when I run `./RetroArch-Linux-x86_64.AppImage -L 2048_libretro.so` is starting the core directly for me, so I rephrased this to `after you have loaded the core and if it is not starting directly, select 'Start Core' that will appear inside the main menu.`

**Todo: The file for https://www.retroarch.com/?page=cores should also be rephrased and a comment should be added that link to both files to make it easy to synchronize the text, I just couldn't find it. Where is it located?**

@hizzlekizzle 