### PR TITLE
Mention explicitly that some GBA cores do not support "SaveRAM Autosave Interval" setting

### DIFF
--- a/docs/library/beetle_gba.md
+++ b/docs/library/beetle_gba.md
@@ -4,6 +4,8 @@
 
 Standalone port of Mednafen GBA to libretro, itself a fork of VBA-M, itself a fork of Visual Boy Advance.
 
+Please notice that [this core do not support libretro save interface](https://github.com/libretro/RetroArch/issues/16323#issuecomment-1977792161), meaning even if you set option "SaveRAM Autosave Interval" on settings, it will only write down internal save game data when you gracefully close emulation (by selecting option "Close Content" on Quick Menu). That might lead to loss of data if you exit RetroArch from your OS app switcher, if it freezes or if shuts down unexpectedly without battery for instance.
+
 ### Author/License
 
 The Beetle GBA core has been authored by

--- a/docs/library/beetle_gba.md
+++ b/docs/library/beetle_gba.md
@@ -4,8 +4,6 @@
 
 Standalone port of Mednafen GBA to libretro, itself a fork of VBA-M, itself a fork of Visual Boy Advance.
 
-Please notice that [this core do not support libretro save interface](https://github.com/libretro/RetroArch/issues/16323#issuecomment-1977792161), meaning even if you set option "SaveRAM Autosave Interval" on settings, it will only write down internal save game data when you gracefully close emulation (by selecting option "Close Content" on Quick Menu). That might lead to loss of data if you exit RetroArch from your OS app switcher, if it freezes or if shuts down unexpectedly without battery for instance.
-
 ### Author/License
 
 The Beetle GBA core has been authored by
@@ -56,6 +54,7 @@ Frontend-level settings or features that the Beetle GBA core respects.
 | Core Options      | ✔         |
 | RetroAchievements | ✔         |
 | RetroArch Cheats  | ✕         |
+| [RetroArch SaveRAM Autosave Interval support](https://github.com/libretro/RetroArch/issues/16323#issuecomment-1977792161) | ✕ |
 | Native Cheats     | ✕         |
 | Controls          | ✔         |
 | Remapping         | ✔         |

--- a/docs/library/compatibility/gba.md
+++ b/docs/library/compatibility/gba.md
@@ -1,6 +1,6 @@
 # Nintendo Game Boy Advance Core Compatibility
 
-Please notice that [only certain cores support libretro save interface](https://github.com/libretro/RetroArch/issues/16323#issuecomment-1977792161), meaning even if you set option "SaveRAM Autosave Interval" on settings, some cores will only write down internal save game data when you gracefully close emulation. That might lead to loss of data.
+Please notice that [only certain cores support libretro save interface](https://github.com/libretro/RetroArch/issues/16323#issuecomment-1977792161), meaning even if you set option "SaveRAM Autosave Interval" on settings, some cores will only write down internal save game data when you gracefully close emulation. That might lead to loss of data if you exit RetroArch from your OS app switcher, if it freezes or if shuts down unexpectedly without battery for instance.
 
 ## Beetle GBA
 

--- a/docs/library/compatibility/gba.md
+++ b/docs/library/compatibility/gba.md
@@ -1,6 +1,14 @@
 # Nintendo Game Boy Advance Core Compatibility
 
+Please notice that [only certain cores support libretro save interface](https://github.com/libretro/RetroArch/issues/16323#issuecomment-1977792161), meaning even if you set option "SaveRAM Autosave Interval" on settings, some cores will only write down internal save game data when you gracefully close emulation. That might lead to loss of data.
+
+## Beetle GBA
+
+[Does not support SaveRAM Autosave Interval.](https://github.com/libretro/RetroArch/issues/16323#issuecomment-1980460281)
+
 ## gpSP
+
+[Does not support SaveRAM Autosave Interval.](https://github.com/libretro/RetroArch/issues/16323#issuecomment-1980460281)
 
 | Game                                  | Issue                          |
 |---------------------------------------|--------------------------------|
@@ -30,7 +38,13 @@
 | ~~Wolfenstein 3D~~                      |~~Softlocks at id Software startup screen.~~|
 | Yoshi’s Universal Gravitation       |The tilt sensor is not emulated.|
 
+## mGBA
+
+[Supports SaveRAM Autosave Interval.](https://github.com/libretro/RetroArch/issues/16323#issuecomment-1980460281)
+
 ## VBA-M
+
+[Supports SaveRAM Autosave Interval.](https://github.com/libretro/RetroArch/issues/16323#issuecomment-1980460281)
 
 | Game                                  | Issue                          |
 |---------------------------------------|--------------------------------|
@@ -42,6 +56,8 @@
 | ~~Yoshi’s Universal Gravitation~~         |   ~~The tilt sensor is not emulated~~   |
 
 ## VBA Next
+
+[Supports SaveRAM Autosave Interval.](https://github.com/libretro/RetroArch/issues/16323#issuecomment-1980460281)
 
 | Game                                              | Issue                                                                                              |
 |---------------------------------------------------|----------------------------------------------------------------------------------------------------|

--- a/docs/library/compatibility/gba.md
+++ b/docs/library/compatibility/gba.md
@@ -1,6 +1,6 @@
 # Nintendo Game Boy Advance Core Compatibility
 
-Please notice that [only certain cores support libretro save interface](https://github.com/libretro/RetroArch/issues/16323#issuecomment-1977792161), meaning even if you set option "SaveRAM Autosave Interval" on settings, some cores will only write down internal save game data when you gracefully close emulation. That might lead to loss of data if you exit RetroArch from your OS app switcher, if it freezes or if shuts down unexpectedly without battery for instance.
+Please notice that when using these cores on RetroArch, [only certain cores support libretro save interface](https://github.com/libretro/RetroArch/issues/16323#issuecomment-1977792161), meaning even if you set option "SaveRAM Autosave Interval" on settings, some cores will only write down internal save game data when you gracefully close emulation. That might lead to loss of data if you exit RetroArch from your OS app switcher, if it freezes or if shuts down unexpectedly without battery for instance.
 
 ## Beetle GBA
 

--- a/docs/library/gpsp.md
+++ b/docs/library/gpsp.md
@@ -4,8 +4,6 @@
 
 gpSP is a Game Boy Advance emulator based on notaz' fork of gpSP with additional codebase improvements.
 
-Please notice that [this core do not support libretro save interface](https://github.com/libretro/RetroArch/issues/16323#issuecomment-1977792161), meaning even if you set option "SaveRAM Autosave Interval" on settings, it will only write down internal save game data when you gracefully close emulation (by selecting option "Close Content" on Quick Menu). That might lead to loss of data if you exit RetroArch from your OS app switcher, if it freezes or if shuts down unexpectedly without battery for instance.
-
 ### Author/License
 
 The gpSP core has been authored by
@@ -54,6 +52,7 @@ Frontend-level settings or features that the gpSP core respects.
 | Core Options      | ✕         |
 | RetroAchievements | ✔         |
 | RetroArch Cheats  | ✔         |
+| [RetroArch SaveRAM Autosave Interval support](https://github.com/libretro/RetroArch/issues/16323#issuecomment-1977792161) | ✕ |
 | Native Cheats     | ✕         |
 | Controls          | ✔         |
 | Remapping         | ✔         |

--- a/docs/library/gpsp.md
+++ b/docs/library/gpsp.md
@@ -4,6 +4,8 @@
 
 gpSP is a Game Boy Advance emulator based on notaz' fork of gpSP with additional codebase improvements.
 
+Please notice that [this core do not support libretro save interface](https://github.com/libretro/RetroArch/issues/16323#issuecomment-1977792161), meaning even if you set option "SaveRAM Autosave Interval" on settings, it will only write down internal save game data when you gracefully close emulation (by selecting option "Close Content" on Quick Menu). That might lead to loss of data if you exit RetroArch from your OS app switcher, if it freezes or if shuts down unexpectedly without battery for instance.
+
 ### Author/License
 
 The gpSP core has been authored by

--- a/docs/library/mgba.md
+++ b/docs/library/mgba.md
@@ -56,6 +56,7 @@ Frontend-level settings or features that the mGBA core respects.
 | Core Options      | ✔         |
 | RetroAchievements | ✔         |
 | RetroArch Cheats  | ✔         |
+| [RetroArch SaveRAM Autosave Interval support](https://github.com/libretro/RetroArch/issues/16323#issuecomment-1977792161) | ✔ |
 | Native Cheats     | ✕         |
 | Controls          | ✔         |
 | Remapping         | ✔         |

--- a/docs/library/vba_m.md
+++ b/docs/library/vba_m.md
@@ -61,6 +61,7 @@ Frontend-level settings or features that the VBA-M core respects.
 | Core Options      | ✔         |
 | RetroAchievements | ✔         |
 | RetroArch Cheats  | ✔         |
+| [RetroArch SaveRAM Autosave Interval support](https://github.com/libretro/RetroArch/issues/16323#issuecomment-1977792161) | ✔ |
 | Native Cheats     | ✔         |
 | Controls          | ✔         |
 | Remapping         | ✔         |

--- a/docs/library/vba_next.md
+++ b/docs/library/vba_next.md
@@ -56,6 +56,7 @@ Frontend-level settings or features that the VBA Next core respects.
 | Core Options      | ✔         |
 | RetroAchievements | ✔         |
 | RetroArch Cheats  | ✕         |
+| [RetroArch SaveRAM Autosave Interval support](https://github.com/libretro/RetroArch/issues/16323#issuecomment-1977792161) | ✔ |
 | Native Cheats     | ✕         |
 | Controls          | ✔         |
 | Remapping         | ✔         |


### PR DESCRIPTION
In order to prevent loss of data when using internal saving and exiting RetroArch in a non-graceful way, as addressed on https://github.com/libretro/RetroArch/issues/16323 and many other times.