### PR TITLE
Update controller-autoconfiguration.md -- Mapping sub-sections

### DIFF
--- a/docs/guides/controller-autoconfiguration.md
+++ b/docs/guides/controller-autoconfiguration.md
@@ -143,12 +143,12 @@ input_menu_toggle_btn = "8"
 
 * Variable names ending with `_axis` define these (e.g., `input_l_x_axis`, `input_r2_axis`).
 * They represent analog inputs from the controller, like joystick position (e.g., left joystick X-axis, right joystick Y-axis) or trigger pressure (e.g., left trigger, right trigger).
-* Axis definitions use `+` and `-` to indicate positive or negative direction (e.g., full press vs. no press).
+* Axis definitions use `+` and `-` that ranges from `0`, to `10` to indicate positive or negative direction (e.g., full press vs. no press).
 
 #### Buttons (digital inputs)
 
 * These are defined by variable names ending with `_btn` (e.g., `input_a_btn`, `input_start_btn`).
-* The values assigned (like "0", "1") are IDs for your controller's buttons.
+* The assigned values (ranging from "0" to "203") are unique IDs for your controller's buttons.
 * RetroArch interprets these IDs (usually 1 for pressed, 0 for not pressed) to determine the button state.
 
 ##### D-Pad directions (special digital inputs)

--- a/docs/guides/controller-autoconfiguration.md
+++ b/docs/guides/controller-autoconfiguration.md
@@ -143,18 +143,20 @@ input_menu_toggle_btn = "8"
 
 * Variable names ending with `_axis` define these (e.g., `input_l_x_axis`, `input_r2_axis`).
 * They represent analog inputs from the controller, like joystick position (e.g., left joystick X-axis, right joystick Y-axis) or trigger pressure (e.g., left trigger, right trigger).
-* Axis definitions use `+` and `-` that ranges from `0`, to `10` to indicate positive or negative direction (e.g., full press vs. no press).
+* Axis definitions use `+` and `-` to indicate positive or negative direction (e.g., full press vs. no press).
+* The current RetroArch configurations have axis values that ranges from `0` to `10`. However, if RetroArch does not limit the values to `10`, underlying controller hardware could offer an even wider range.
 
 #### Buttons (digital inputs)
 
 * These are defined by variable names ending with `_btn` (e.g., `input_a_btn`, `input_start_btn`).
-* The assigned values (ranging from "0" to "203") are unique IDs for your controller's buttons.
+* The current RetroArch configurations have button values that ranges from `0` to `203`. However, if RetroArch does not limit the values to `203`, underlying controller hardware could offer an even wider range.
 * RetroArch interprets these IDs (usually 1 for pressed, 0 for not pressed) to determine the button state.
 
 ##### D-Pad directions (special digital inputs)
 
 * D-pad directions use variable values beginning with `h0` (e.g., `input_up_btn = "h0up"`).
 * Four `h0` variables exist (`h0up`, `h0down`, `h0left`, `h0right`) for each direction on the D-pad.
+* Note: The value `h1` is used by a single controller (Nintendo_Wii_Remote_Classic_Controller.cfg).
 
 ### Input descriptors
 

--- a/docs/guides/controller-autoconfiguration.md
+++ b/docs/guides/controller-autoconfiguration.md
@@ -109,7 +109,7 @@ input_product_id = "3570"
 
 ### Mapping
 
-The second part is the mapping itself, where each button is assigned to a button of the RetroPad (the joypad abstraction of RetroArch):
+The second part is the mapping itself, where each button is assigned to a button of the RetroPad (the joypad abstraction of RetroArch).
 
 ```
 input_b_btn = "0"
@@ -138,6 +138,19 @@ input_r_y_plus_axis = "+4"
 input_r_y_minus_axis = "-4"
 input_menu_toggle_btn = "8"
 ```
+
+#### Axes (analog inputs)
+
+Axes (variable names ending with the suffix `_axis`) in libretro autoconfigs are used for analog inputs from the controller. These axes use a continuous range of values to represent the position of the joystick (e.g., `input_l_x_axis` for the left joystick's X-axis, `input_r_y_axis` for the right joystick's Y-axis) or the pressure applied to a trigger (e.g., `input_l2_axis` for the left trigger, `input_r2_axis` for the right trigger). Axis definitions use `+`/`-` to indicate positive or negative direction (e.g., full press vs. no press).
+
+#### Buttons (digital inputs)
+
+Buttons (variable names ending with the suffix `_btn`) in libretro autoconfigs use IDs (like "0", "1", "2") to identify buttons on your controller. These IDs have no inherent meaning about the pressed state (typically handled by RetroArch as 1 for pressed, 0 for not pressed). The mappings link these IDs to the buttons on the RetroPad within RetroArch (e.g., `input_b_btn = "0"` assigns the controller's B button to the B button on the RetroPad).
+
+#### D-Pad directions (special digital inputs)
+
+D-pad directions (variable names with the prefix `h0`) are also digital inputs, but they are special. These entries specify whether a particular direction on the D-pad is pressed (typically registering as a 1) or not pressed (typically registering as a 0). The h0 prefix likely refers to the first D-pad on the controller (if there's more than one).
+
 
 ### Input descriptors
 

--- a/docs/guides/controller-autoconfiguration.md
+++ b/docs/guides/controller-autoconfiguration.md
@@ -141,16 +141,20 @@ input_menu_toggle_btn = "8"
 
 #### Axes (analog inputs)
 
-Axes (variable names ending with the suffix `_axis`) in libretro autoconfigs are used for analog inputs from the controller. These axes use a continuous range of values to represent the position of the joystick (e.g., `input_l_x_axis` for the left joystick's X-axis, `input_r_y_axis` for the right joystick's Y-axis) or the pressure applied to a trigger (e.g., `input_l2_axis` for the left trigger, `input_r2_axis` for the right trigger). Axis definitions use `+`/`-` to indicate positive or negative direction (e.g., full press vs. no press).
+* Variable names ending with `_axis` define these (e.g., `input_l_x_axis`, `input_r2_axis`).
+* They represent analog inputs from the controller, like joystick position (e.g., left joystick X-axis, right joystick Y-axis) or trigger pressure (e.g., left trigger, right trigger).
+* Axis definitions use `+` and `-` to indicate positive or negative direction (e.g., full press vs. no press).
 
 #### Buttons (digital inputs)
 
-Buttons (variable names ending with the suffix `_btn`) in libretro autoconfigs use IDs (like "0", "1", "2") to identify buttons on your controller. These IDs have no inherent meaning about the pressed state (typically handled by RetroArch as 1 for pressed, 0 for not pressed). The mappings link these IDs to the buttons on the RetroPad within RetroArch (e.g., `input_b_btn = "0"` assigns the controller's B button to the B button on the RetroPad).
+* These are defined by variable names ending with `_btn` (e.g., `input_a_btn`, `input_start_btn`).
+* The values assigned (like "0", "1") are IDs for your controller's buttons.
+* RetroArch interprets these IDs (usually 1 for pressed, 0 for not pressed) to determine the button state.
 
-#### D-Pad directions (special digital inputs)
+##### D-Pad directions (special digital inputs)
 
-D-pad directions (variable names with the prefix `h0`) are also digital inputs, but they are special. These entries specify whether a particular direction on the D-pad is pressed (typically registering as a 1) or not pressed (typically registering as a 0). The h0 prefix likely refers to the first D-pad on the controller (if there's more than one).
-
+* D-pad directions use variable values beginning with `h0` (e.g., `input_up_btn = "h0up"`).
+* Four `h0` variables exist (`h0up`, `h0down`, `h0left`, `h0right`) for each direction on the D-pad.
 
 ### Input descriptors
 


### PR DESCRIPTION
Clarified button IDs, detailed D-pad directions, and covered both analog (axes) and digital (buttons, D-pad) inputs for controller mapping within RetroArch.