### PR TITLE
Updated m2000.md

### DIFF
--- a/docs/library/m2000.md
+++ b/docs/library/m2000.md
@@ -26,7 +26,6 @@ A summary of the licenses behind RetroArch and its cores can be found [here](../
 Content that can be loaded by the M2000 core have the following file extensions:
 
 - .cas
-- .p2000t
 
 ## Features
 


### PR DESCRIPTION
M2000 only supports the .cas extension. The .p2000t extension was experimental, but turned out to be confusing and actually never used.