### PR TITLE
[CONSULTATION NEEDED] Update input-controller-drivers.md: Updated the "Linux Controller Drivers" section

### DIFF
--- a/docs/guides/input-controller-drivers.md
+++ b/docs/guides/input-controller-drivers.md
@@ -26,7 +26,6 @@ RetroArch makes use of two input systems in order to support the full range of i
 - linuxraw
 - sdl2
 - udev
-- xinput
 
 ### udev input driver
 udev is the newest input driver and uses the evdev joypad interface at `/dev/input`. It supports hotplugging and force feedback (if supported by device). udev reads evdev events directly and supports keyboard callback, mice, and touchpads. `libudev` is used to discover devices and support hotplugging.

--- a/docs/guides/input-controller-drivers.md
+++ b/docs/guides/input-controller-drivers.md
@@ -10,6 +10,11 @@ RetroArch makes use of two input systems in order to support the full range of i
 
 **Absolute mouse devices** in the tables below refers to input drivers which support mouse-like devices such as light guns, air mice, and Wiimotes that use 'absolute' coordinate systems. Certain input drivers only support mouse devices with 'relative' coordinate systems.
 
+## Apple OSes
+
+**Apple Controller Drivers[^1]**
+- mfi
+
 ## Linux
 `udev` is the most full-featured Input Driver and Controller Driver for Linux.
 
@@ -315,3 +320,14 @@ The older linuxraw driver is available which uses the legacy joystick API at `/d
 | Rumble |
 |--------|
 | -    |
+
+## QNX
+
+### QNX controller driver
+- QNX
+
+# Fotnotes
+[^1]: MFi controllers are primarily supported on Apple devices, which means that the operating systems supporting this configuration would include:
+- iOS: Used on iPhones and iPads.
+- macOS: Used on Mac computers.
+- tvOS: Used on Apple TV devices.

--- a/docs/guides/input-controller-drivers.md
+++ b/docs/guides/input-controller-drivers.md
@@ -26,6 +26,7 @@ RetroArch makes use of two input systems in order to support the full range of i
 - linuxraw
 - sdl2
 - udev
+- [parport](https://docs.libretro.com/development/retroarch/input/parallel-port-controllers/)
 
 ### udev input driver
 udev is the newest input driver and uses the evdev joypad interface at `/dev/input`. It supports hotplugging and force feedback (if supported by device). udev reads evdev events directly and supports keyboard callback, mice, and touchpads. `libudev` is used to discover devices and support hotplugging.

--- a/docs/guides/input-controller-drivers.md
+++ b/docs/guides/input-controller-drivers.md
@@ -22,7 +22,6 @@ RetroArch makes use of two input systems in order to support the full range of i
 
 **Linux Controller Drivers**
 
-- hid
 - linuxraw
 - sdl2
 - udev


### PR DESCRIPTION
# Not documented yet:
Please document the following controller drivers in this PR before we approve it:
* [mfi](https://github.com/libretro/retroarch-joypad-autoconfig/tree/master/mfi)
* [qnx](https://github.com/libretro/retroarch-joypad-autoconfig/tree/master/qnx)
* [x](https://github.com/libretro/retroarch-joypad-autoconfig/tree/master/x)

# Added "parport"
Available for RetroArch in the Flatpak, AppImage, or APT package formats.

# Removed "hid"
Found via `sudo apt-get install retroarch` in Ubuntu MATE 22.04 but it's broken.[1] Not found in Ubuntu MATE 23.04 or 24.04. "hid" is not found in the Flatpak or AppImage packages.

**Perhaps it is utilized by other distros? Can anyone else please confirm that it should be removed from the "Linux Controller Drivers" section?**

I didn't remove "hid" from https://docs.libretro.com/guides/input-controller-drivers/#windows

1: a) Change the controller driver b) Restart RetroArch for the Setting to take effect. c) Settings -> Input -> Input User 1 Binds -> User 1 Bind All

# Removed "xinput"
A proprietary controller driver developed by Microsoft not available for RetroArch in the Flatpak, AppImage, or APT package formats.

**Can anyone else please confirm that it should be removed from the "Linux Controller Drivers" section?**

I didn't remove "xinput" from https://docs.libretro.com/guides/input-controller-drivers/#windows
