### PR TITLE
Beetle Saturn - Correct Core's provided FPS

### DIFF
--- a/docs/library/beetle_saturn.md
+++ b/docs/library/beetle_saturn.md
@@ -97,7 +97,7 @@ The Beetle Saturn core saves/loads to/from these directories.
 
 ## Geometry and timing
 
-- The Beetle Saturn core's core provided FPS is 59.88 for NTSC games and 49.96 for PAL games
+- The Beetle Saturn core's core provided FPS is 59.83 for NTSC games and 49.92 for PAL games
 - The Beetle Saturn core's core provided sample rate is 44100 Hz
 - The Beetle Saturn core's base width is 320
 - The Beetle Saturn core's base height is 240


### PR DESCRIPTION
It was wrong, the correct infos are : 

- 59.83 for NTSC games
- 49.92 for PAL games

It now matches the actual internal FPS on the core.

Source : https://github.com/sonninnos/beetle-saturn-libretro/blob/master/libretro.cpp

if (retro_get_region() == RETRO_REGION_PAL)
      info->timing.fps            = 49.92012779552716;
   else
      info->timing.fps            = 59.82650314089141;