### PR TITLE
melonDS DS: Add docs for LAN multiplayer

### DIFF
--- a/docs/library/melonds_ds.md
+++ b/docs/library/melonds_ds.md
@@ -214,18 +214,6 @@ This setting will cause issues on LAN multiplayer
 if more than one player has the same username.
 The username can be set on RetroArch by going to "Settings", "User", "Username".
 
-* Read from a file:
-By adding a txt file that contains a formatted MAC address
-in the "system" folder of the libretro frontend or a subfolder of the "system" folder named "melonDS DS",
-an option will appear to set the MAC address from the file.
-The file must be encoded in ASCII,
-and the MAC address must be formatted as "00:00:00:00:00".
-The MAC address must be the first line in the file,
-and there must be no other text before the MAC address.
-The MAC address must only use uppercase letters and digits in the hexadecimal numbers.
-As with all other settings,
-this setting will cause issues if more than one player in a multiplayer session has the same MAC address.
-
 ### Starting a multiplayer session (RetroArch)
 Before starting a multiplayer session,
 it is recommended that all set a proper username in "Settings", "User", "Username", in RetroArch,

--- a/docs/library/melonds_ds.md
+++ b/docs/library/melonds_ds.md
@@ -156,7 +156,92 @@ If there's another server you'd like to use, you can set its DNS address from wi
 
 ## LAN Netplay
 
-Coming soon...
+melonDS DS supports emulating LAN multiplayer via netplay. See below for instructions and details.
+
+### What is LAN Multiplayer?
+The Nintendo DS has several forms of multiplayer,
+including local Wi-Fi (also called LAN), Nintendo Wi-Fi Connection (WFC) and infrared.
+You'll know when games use local Wi-Fi if the game mentions "Wi-Fi" and "players nearby",
+while games using WFC mention "players around the world" and use friend codes.
+The Nintendo DS local Wi-Fi does not use friend codes.
+This page only explains local Wi-Fi multiplayer.
+
+Now, the Nintendo DS local Wi-Fi isn't the normal Wi-Fi in your house,
+it is a [mesh network that uses specialized hardware](https://melonds.kuribo64.net/comments.php?id=25).
+This means that games expect extremely low latency,
+which is achievable between two consoles directly connected with special hardware,
+but harder to achieve with two computers with a router in-between,
+and simply **impossible** to achieve through the Internet.
+**LAN multiplayer does not work through the Internet and neither with VPNs or tunnels such as Hamachi**.
+This is not something that can be fixed easily.
+**The only way to use emulated LAN Multiplayer is on an actual, low latency, wired LAN connection**.
+
+The latency requirements are so extreme that even in LAN, you might still have issues.
+That is why using Wi-Fi in your LAN connection is not recommended,
+Wi-Fi simply adds too much latency,
+and the connection will drop frequently.
+The recommended way to use the emulated Wi-Fi LAN connection is with a wired LAN connection between the computers.
+
+### What is a MAC address?
+Every Nintendo DS (and every device capable of Wi-Fi) comes with an identifier built-in in its firmware called a "MAC address".
+For three or more Nintendo DS consoles to connect in a local Wi-Fi multiplayer network,
+all three need to have different MAC addresses.
+You can see the emulated console's MAC address in a game with Nintendo WFC
+by going to "Nintendo WFC Settings", "Options", "System Information".
+
+Some games will refuse to load save files
+that were created on a console with a different MAC address
+than the console loading the file.
+That is why it is important to pay attention to your MAC address when sharing save files across devices.
+
+So how does the emulated console obtain a MAC address?
+It depends on the core option "MAC address mode", in the "Network" category:
+
+* Set from firmware:
+The default setting.
+The emulator will use the firmware file's MAC address for the emulated console.
+If there is no firmware file, then a default MAC address of "00-09-BF-11-22-33" will be used.
+This setting will cause issues on LAN multiplayer with more than 2 players
+if the same firmware (or the default firmware) is used on more than one device.
+
+* Derive from libretro username:
+The emulator will use your username as set on the libretro frontend to automatically generate a MAC address.
+Such generated MAC addresses will start with "00-08-BF".
+Devices with the same username set will always generate the same MAC address.
+Useful when syncing save files across devices
+to guarantee the emulated console's MAC address is the same on all devices.
+This setting will cause issues on LAN multiplayer
+if more than one player has the same username.
+The username can be set on RetroArch by going to "Settings", "User", "Username".
+
+* Read from a file:
+By adding a txt file that contains a formatted MAC address
+in the "system" folder of the libretro frontend or a subfolder of the "system" folder named "melonDS DS",
+an option will appear to set the MAC address from the file.
+The file must be encoded in ASCII,
+and the MAC address must be formatted as "00:00:00:00:00".
+The MAC address must be the first line in the file,
+and there must be no other text before the MAC address.
+The MAC address must only use uppercase letters and digits in the hexadecimal numbers.
+As with all other settings,
+this setting will cause issues if more than one player in a multiplayer session has the same MAC address.
+
+### Starting a multiplayer session (RetroArch)
+Before starting a multiplayer session,
+it is recommended that all set a proper username in "Settings", "User", "Username", in RetroArch,
+and set the MAC address mode to "Derive from libretro username".
+
+In RetroArch, such a multiplayer session can be started through the "Netplay" menu either before starting a game or during a game.
+One player should host and the others should use the "Refresh Netplay LAN List" option to join.
+In game, you'd look for something mentioning local multiplayer and "players nearby".
+In Pokémon games, this can be accessed on the top floor of Pokémon centers,
+in Mario Kart DS, it is the "Multiplayer" option in the menu etc.
+There are a ton of pages online saying that "Netplay is not network emulation".
+For various reasons, these pages are wrong when it comes to melonDS DS.
+
+Again, emulated LAN multiplayer only works if all players are on the same real local network.
+This means the same house, apartment etc.
+For better results, a wired connection is recommended.
 
 ## DSi
 


### PR DESCRIPTION
A bit of explanation for melonDS DS local multiplayer emulation because it can be quite complex to set up.
@JesseTG because he is the maintainer of melonDS DS.
Draft because the functionality is not actually released yet.