### PR TITLE
Add a missing package in dkp-pacman invocation

### DIFF
--- a/docs/development/retroarch/compilation/switch-libnx.md
+++ b/docs/development/retroarch/compilation/switch-libnx.md
@@ -9,7 +9,7 @@ Then, install all the required libraries:
     - replace `dkp-pacman` by `pacman` on Linux and Mac OS
 
 ```
-dkp-pacman -Sy devkit-env devkitA64 libnx switch-tools switch-mesa switch-zlib switch-bzip2 switch-liblzma switch-freetype switch-libpng switch-libvpx switch-ffmpeg
+dkp-pacman -Sy devkit-env devkitA64 libnx switch-tools switch-mesa switch-zlib switch-bzip2 switch-liblzma switch-freetype switch-libpng switch-libvpx switch-ffmpeg switch-libopus
 ```
 
 ## RetroArch Compilation


### PR DESCRIPTION
Missing switch-libopus results in
`ld: cannot find -lopus: No such file or directory`