### PR TITLE
Update generating-retroarch-logs.md to prevent pwsh confusion on Windows

### DIFF
--- a/docs/guides/generating-retroarch-logs.md
+++ b/docs/guides/generating-retroarch-logs.md
@@ -46,6 +46,7 @@ This will place the logs in the System Events Logs directory, visible in the "Di
 !!! tip
     You can hold `shift` then `right click` on the **folder that contains** retroarch.exe <br />
     Select `Open PowerShell window here`.<br />
+    In the PowerShell window, use the `cmd` command to switch to the Windows console.
     Then jump to step 3.
 
 1. Open a console window with the `cmd` command, found either in the Start Menu or through use of the Windows "Run" menu.


### PR DESCRIPTION
The Windows directions contain a tip to use a folder context menu to open a PowerShell instance in that location. However, the remainder of the commands will fail as pwsh, like bash and other *nix-style shells, does not include . in the path. To sidestep this and avoid having parallel sets of steps (one including "./" and one without), a step was added to the tip to switch to cmd within that PowerShell instance.