### PR TITLE
Major simplification/rewrite of Android Install guide

### DIFF
--- a/docs/guides/install-android.md
+++ b/docs/guides/install-android.md
@@ -1,7 +1,5 @@
 # Downloading, Installing and Updating RetroArch for Android devices.
 
-<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/dqx5c28pT3o" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-
 ### Installation via Website
 ___
 1. Visit the retroarch.com [Downloads page](https://www.retroarch.com/?page=platforms) and select **Download Stable** or **Download Nightly**.

--- a/docs/guides/install-android.md
+++ b/docs/guides/install-android.md
@@ -2,51 +2,30 @@
 
 <iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/dqx5c28pT3o" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
-## Downloading and installing
-___
-There are multiple ways of downloading RetroArch for your Android device. Depending on your Android phone's architecture, you may want to install 64 bit instead of 32 bit.
-
-### Installation via Google Play
-___
-1. Open the Google Play Store app ![Google Play Store Logo](../image/guides/google-playstore-logo.png)
- * Note: you can also go to play.google.com
-2. Search for **RetroArch**.
-3. Select **RetroArch** then **Download**.
-
-This will download the latest stable version. Or you can go to the Google Play Store page by clicking here for [64bit](https://play.google.com/store/apps/details?id=com.retroarch.aarch64&hl=en_US "RetroArch64") or by clicking here for [32bit](https://play.google.com/store/apps/details?id=com.retroarch&hl=en "RetroArch").
-
 ### Installation via Website
 ___
-**Unknown Sources** To avoid compromising the safety of your device, always use applications provided through our official channels.
-
-1. Go to www.retroarch.com then click **Get RetroArch** or [click here](https://www.retroarch.com/?page=platforms) on your device.
-2. Scroll down until **Android** section.
-3. Select either **Download** or **Download (64bit)**.
-> There are several ways to determine if you have 64bit or 32bit version. You can use app like *Antutu* or *AIDA64*. You can still find out without app.
->>
->Go to `Settings` - `System` and check `Kernel version`. If the code inside contains **x64** string, your device has a `64-bit OS`; if you cannot find this string, then is **32-bit**.
-4. Click on the downloaded APK file.
-
-> **Before Android Oreo**:
->>
-> * Enter your device settings.
-> * Go to `Security`.
-> * Find the `Unknown Sources` option and check the box. A warning will pop up which you should definitely read. Once done, hit `OK` and this will enable you to install APKs from Unknown Sources.
-
-> **After Android Oreo**:
->>
-> * Begin installation with a file browser or through the web browser.
-> * Android will tell you that `the app doesn’t have permission to install APKs`. Click the available `Settings` button in that prompt.
-> * In the next menu, tick the box that lets that app install APKs.
+1. Visit the retroarch.com [Downloads page](https://www.retroarch.com/?page=platforms) and select **Download Stable** or **Download Nightly**.
+2. Open the downloaded APK (via a file manager if your browser does not prompt you when the download is completed).
+3. Select Install.
+> * Android may tell you that `the app doesn’t have permission to install APKs`. Click the available `Settings` button in that prompt.
+> * In the next menu, turn on the toggle allowing the app install APKs.
 > * `Hit the back button` to return to your installation.
 
 ### Installation via F-Droid
 ___
-RetroArch can also be found in the F-Droid repository. You can find more information [here](https://f-droid.org/packages/com.retroarch/). 
+RetroArch's most recent stable release can be found [in the F-Droid repository](https://f-droid.org/packages/com.retroarch/) for easier automatic updating.
 
-## Download with Buildbot
+### Other Versions via Buildbot
 ___
-You can either choose `Nightlies` or `Stable` bundle, you can find a bundle with RetroArch, all the cores and all the assets [here](https://buildbot.libretro.com/stable/{{ unit.stable }}/android/), and download `RetroArch.apk` or `RetroArch_aarch64.apk`.
+All [stable](https://buildbot.libretro.com/stable/{{ unit.stable }}/android/) and [nightly](https://buildbot.libretro.com/nightly/android/) bundles are available via BuildBot If you need a specific architecture or build for testing. Builds are named with an architecture suffix: `aarch64` is a 64-bit build, `ra32` is a 32-bit build, and no suffix is a universal build that opts for 64-bit if your system supports it.
+> 32-bit support on Android is slowly being phased out by the industry, but these builds remain available for older devices or specific use cases.
 
-For Nightlies [here](https://buildbot.libretro.com/nightly/android/) - pick the latest version(based on date), and download `...RetroArch.apk` or `...RetroArch_aarch64.apk`.
-(*where ... represents the date*)
+### (NOT RECOMMENDED) Installation via Google Play
+___
+RetroArch is available on the Google Play Store, but has not been updated for years due to Play Store policy changes. You may choose to use this older version, but it is not recommended.
+
+[RetroArch Plus on the Play Store](https://play.google.com/store/apps/details?id=com.retroarch.aarch64&hl=en_US "RetroArch64") (Only for 64 bit devices, additional cores)
+
+[RetroArch on the Play Store](https://play.google.com/store/apps/details?id=com.retroarch&hl=en "RetroArch") (For 32 or 64 bit devices, fewer cores)
+
+A more detailed difference between the Play Store versions can be found in [this libretro blog post](https://www.libretro.com/index.php/retroarch-android-new-versions-for-play-store-please-read/).


### PR DESCRIPTION
Quite a few changes wrapped into one here, mostly explained in the extended commit message. Major impetus for any change was marking Google Play as not recommended and it sort of spiraled from there. Updated the installation process as the Download Stable/Nightly buttons automatically go to the best APK for the vast majority of people. Put the 32/64-bit info into the "Other Versions" section with Buildbot. Removed install instructions for Android versions 7 and below (less than 3% of Android market).

Lots of general language cleanup and organization.

As a separate commit in case you'd prefer to revert, I removed the video embed as it showcases Google Play installation first, which is no longer recommended.