### PR TITLE
Add docs for ClownMDEmu

### DIFF
--- a/docs/development/licenses.md
+++ b/docs/development/licenses.md
@@ -86,6 +86,7 @@ See below for a summary of the licenses behind RetroArch and its cores:
 | [ChaiLove](../library/chailove.md)               			           | [MIT](https://github.com/libretro/libretro-chailove/blob/master/COPYING)                        |                |
 | [Citra](../library/citra.md)                     			           | [GPLv2](https://github.com/citra-emu/citra/blob/master/license.txt)                       |                |
 | [Citra Canary/Experimental](../library/citra_canary.md)              | [GPLv2](https://github.com/citra-emu/citra/blob/master/license.txt)                       |                |
+| [ClownMDEmu](../library/clownmdemu.md)                     			   | [AGPLv3](https://github.com/Clownacy/clownmdemu-libretro/blob/master/LICENCE.txt)         |                |
 | [Craft](../library/craft.md)                     			           | [MIT](https://github.com/libretro/Craft/blob/master/LICENSE.md)                           |                |
 | [CrocoDS](../library/crocods.md)                 			           | [MIT](https://github.com/libretro/libretro-crocods/blob/master/LICENSE)                   |                |
 | [DeSmuME 2015](../library/desmume_2015.md)                           | [GPLv2](https://github.com/libretro/desmume2015/blob/master/desmume/COPYING)              |                |

--- a/docs/guides/core-list.md
+++ b/docs/guides/core-list.md
@@ -46,6 +46,7 @@
 | [Citra](../library/citra.md)               | Nintendo 3DS           |                    |
 | Citra 2018                | Nintendo 3DS           |                    |
 | [Citra Canary](../library/citra_canary.md) | Nintendo 3DS           | Based on Citra development branch |
+| [ClownMDEmu](../library/clownmdemu.md)     | Sega MD/CD             |                    |
 | Craft                     | Game                   | A basic clone of the Minecraft sandbox game |
 | [CrocoDS](../library/crocods.md)           | Amstrad CPC            |                    |
 | Cruzes                    | Game                   | (Further information required) |

--- a/docs/guides/retroachievements.md
+++ b/docs/guides/retroachievements.md
@@ -284,6 +284,7 @@ You can also check the progress of your friends and add comments on their trophi
 |----------------------------------------------------------------|:---------:|:------|
 | [Genesis Plus GX](https://github.com/libretro/Genesis-Plus-GX) | ✔         | Preferred core. |
 | [BlastEm](https://github.com/libretro/blastem)                 | ✕         | Cycle accurate. Genesis/MegaDrive only. Has known issues with game RAM and is incompatible with achievements. |
+| [ClownMDEmu](https://github.com/Clownacy/clownmdemu-libretro)  | ✕         |       |
 | [Picodrive](https://github.com/libretro/picodrive)             | ✔         |       |
 | [SMS Plus GX](https://github.com/libretro/smsplus-gx)          | ✔         | Master System only |
 | [Gearsystem](https://github.com/drhelius/Gearsystem)           | ✔         | Master System only |
@@ -320,6 +321,7 @@ You can also check the progress of your friends and add comments on their trophi
 | Core                                                           | Supported | Notes |
 |----------------------------------------------------------------|:---------:|:------|
 | [Genesis Plus GX](https://github.com/libretro/Genesis-Plus-GX) | ✔         |       |
+| [ClownMDEmu](https://github.com/Clownacy/clownmdemu-libretro)  | ✕         |       |
 | [Picodrive](https://github.com/libretro/picodrive)             | ✔         |       |
 
 #### Saturn

--- a/docs/guides/softpatching.md
+++ b/docs/guides/softpatching.md
@@ -105,6 +105,7 @@ rom.ips2
 | Core                                             | Supported |
 |--------------------------------------------------|:---------:|
 | [BlastEm](../library/blastem.md)                 | ✔         |
+| [ClownMDEmu](../library/clownmdemu.md)           | ✔         |
 | [Genesis Plus GX](../library/genesis_plus_gx.md) | ✔         |
 | [PicoDrive](../library/picodrive.md)             | ✕         |
 

--- a/docs/library/clownmdemu.md
+++ b/docs/library/clownmdemu.md
@@ -1,0 +1,235 @@
+# ClownMDEmu
+
+## Background
+
+A highly-portable Sega Mega Drive emulator that aims to be as fast as possible without sacrificing accuracy.
+
+The ClownMDEmu core has been authored by:
+
+- Clownacy
+
+The ClownMDEmu core is licensed under:
+
+- [AGPLv3](https://github.com/Clownacy/clownmdemu-libretro/blob/master/LICENCE.txt)
+
+A summary of the licenses behind RetroArch and its cores can be found [here](../development/licenses.md).
+
+## Extensions
+
+Content that can be loaded by the ClownMDEmu core have the following file extensions:
+
+- .bin
+- .md
+- .gen
+- .cue
+- .iso
+
+RetroArch database(s) that are associated with the ClownMDEmu core:
+
+- [Sega - Mega Drive - Genesis](https://github.com/libretro/libretro-database/blob/master/rdb/Sega%20-%20Mega%20Drive%20-%20Genesis.rdb)
+- [Sega - Mega-CD - Sega CD](https://github.com/libretro/libretro-database/blob/master/rdb/Sega%20-%20Mega-CD%20-%20Sega%20CD.rdb)
+
+## Features
+
+Frontend-level settings or features that the ClownMDEmu core respects:
+
+| Feature           | Supported |
+|-------------------|-----------|
+| Restart           | ✔         |
+| Saves             | ✔         |
+| States            | ✔         |
+| Rewind            | ✔         |
+| Netplay           | ✔         |
+| Core Options      | ✔         |
+| RetroAchievements | ✕         |
+| RetroArch Cheats  | ✕         |
+| Native Cheats     | ✕         |
+| Controls          | ✔         |
+| Remapping         | ✔         |
+| Multi-Mouse       | ✕         |
+| Rumble            | ✕         |
+| Sensors           | ✕         |
+| Camera            | ✕         |
+| Location          | ✕         |
+| Subsystem         | ✕         |
+| [Softpatching](../guides/softpatching.md) | ✔         |
+| Disk Control      | ✕         |
+| Username          | ✕         |
+| Language          | ✕         |
+| Crop Overscan     | ✕         |
+| LEDs              | ✕         |
+
+## Directories
+
+The ClownMDEmu core's library name is 'ClownMDEmu'.
+
+The ClownMDEmu core saves/loads to/from these directories.
+
+**Frontend's Save directory**
+
+| File  | Description                  |
+|-------|------------------------------|
+| *.srm | Mega Drive/Genesis save data |
+| *.brm | Mega CD/Sega CD save data    |
+
+**Frontend's State directory**
+
+| File     | Description |
+|----------|-------------|
+| *.state# | State       |
+
+## Geometry and timing
+
+- The ClownMDEmu core's core-provided FPS is 59.94 for NTSC games and 50 for PAL games
+- The ClownMDEmu core's core-provided sample rate is 223721.5625 Hz
+- The ClownMDEmu core's base width is 320 (though this varies depending on the loaded content)
+- The ClownMDEmu core's base height is 224 (though this varies depending on the loaded content)
+- The ClownMDEmu core's max width is 320
+- The ClownMDEmu core's max height is 480
+- The ClownMDEmu core's core-provided aspect ratio is typically 10:7 (though this varies depending on the loaded content)
+
+## Core options
+
+The ClownMDEmu core has the following option(s) that can be tweaked from the core options menu. The default setting is bolded.
+
+- **Debug > Disable Sprite Plane** [clownmdemu_disable_sprite_plane] (**disabled**|enabled)
+
+	Disable the VDP's Sprite Plane.
+
+- **Debug > Disable Window Plane** [clownmdemu_disable_window_plane] (**disabled**|enabled)
+
+	Disable the VDP's Window Plane.
+
+- **Debug > Disable Plane A** [clownmdemu_disable_plane_a] (**disabled**|enabled)
+
+	Disable the VDP's Plane A.
+
+- **Debug > Disable Plane B** [clownmdemu_disable_plane_b] (**disabled**|enabled)
+
+	Disable the VDP's Plane B.
+
+- **Debug > Disable FM1** [clownmdemu_disable_fm1] (**disabled**|enabled)
+
+	Disable the YM2612's FM1 channel.
+
+- **Debug > Disable FM2** [clownmdemu_disable_fm2] (**disabled**|enabled)
+
+	Disable the YM2612's FM2 channel.
+
+- **Debug > Disable FM3** [clownmdemu_disable_fm3] (**disabled**|enabled)
+
+	Disable the YM2612's FM3 channel.
+
+- **Debug > Disable FM4** [clownmdemu_disable_fm4] (**disabled**|enabled)
+
+	Disable the YM2612's FM4 channel.
+
+- **Debug > Disable FM5** [clownmdemu_disable_fm5] (**disabled**|enabled)
+
+	Disable the YM2612's FM5 channel.
+
+- **Debug > Disable FM6** [clownmdemu_disable_fm6] (**disabled**|enabled)
+
+	Disable the YM2612's FM6 channel.
+
+- **Debug > Disable DAC** [clownmdemu_disable_dac] (**disabled**|enabled)
+
+	Disable the YM2612's DAC channel.
+
+- **Debug > Disable PSG1** [clownmdemu_disable_psg1] (**disabled**|enabled)
+
+	Disable the SN76496's PSG1 channel.
+
+- **Debug > Disable PSG2** [clownmdemu_disable_psg2] (**disabled**|enabled)
+
+	Disable the SN76496's PSG2 channel.
+
+- **Debug > Disable PSG3** [clownmdemu_disable_psg3] (**disabled**|enabled)
+
+	Disable the SN76496's PSG3 channel.
+
+- **Debug > Disable PSG Noise** [clownmdemu_disable_psg_noise] (**disabled**|enabled)
+
+	Disable the SN76496's PSG Noise channel.
+
+- **Debug > Disable PCM1** [clownmdemu_disable_pcm1] (**disabled**|enabled)
+
+	Disable the RF5C164's PCM1 channel.
+
+- **Debug > Disable PCM2** [clownmdemu_disable_pcm2] (**disabled**|enabled)
+
+	Disable the RF5C164's PCM2 channel.
+
+- **Debug > Disable PCM3** [clownmdemu_disable_pcm3] (**disabled**|enabled)
+
+	Disable the RF5C164's PCM3 channel.
+
+- **Debug > Disable PCM4** [clownmdemu_disable_pcm4] (**disabled**|enabled)
+
+	Disable the RF5C164's PCM4 channel.
+
+- **Debug > Disable PCM5** [clownmdemu_disable_pcm5] (**disabled**|enabled)
+
+	Disable the RF5C164's PCM5 channel.
+
+- **Debug > Disable PCM6** [clownmdemu_disable_pcm6] (**disabled**|enabled)
+
+	Disable the RF5C164's PCM6 channel.
+
+- **Debug > Disable PCM7** [clownmdemu_disable_pcm7] (**disabled**|enabled)
+
+	Disable the RF5C164's PCM7 channel.
+
+- **Debug > Disable PCM8** [clownmdemu_disable_pcm8] (**disabled**|enabled)
+
+	Disable the RF5C164's PCM8 channel.
+
+- **TV Standard** [clownmdemu_tv_standard] (**NTSC (59.94Hz)**|PAL (50Hz))
+
+	Which television standard to output in.
+
+- **Console Region** [clownmdemu_overseas_region] (**Overseas (Elsewhere)**|Domestic (Japan))
+
+	Which region the console is.
+
+- **Tall Interlace Mode 2** [clownmdemu_tall_interlace_mode_2] (**disabled**|enabled)
+
+	Makes games that use Interlace Mode 2 for split-screen not appear squashed.
+
+- **Low-Pass Filter** [clownmdemu_lowpass_filter] (**enabled**|disabled)
+
+	Makes the audio sound 'softer', just like on a real Mega Drive.
+
+- **Low-Volume Distortion** [clownmdemu_ladder_effect] (**enabled**|disabled)
+
+	Approximates the so-called 'ladder effect' that is present in early Mega Drives. Without this, certain sounds in some games will be too quiet.
+
+## Joypad
+
+| RetroPad Inputs                                | User 1 - 2 input descriptors |
+|------------------------------------------------|------------------------------|
+| ![](../image/retropad/retro_b.png)             | B                            |
+| ![](../image/retropad/retro_y.png)             | A                            |
+| ![](../image/retropad/retro_select.png)        | Mode                         |
+| ![](../image/retropad/retro_start.png)         | Start                        |
+| ![](../image/retropad/retro_dpad_up.png)       | Up                           |
+| ![](../image/retropad/retro_dpad_down.png)     | Down                         |
+| ![](../image/retropad/retro_dpad_left.png)     | Left                         |
+| ![](../image/retropad/retro_dpad_right.png)    | Right                        |
+| ![](../image/retropad/retro_a.png)             | C                            |
+| ![](../image/retropad/retro_x.png)             | Y                            |
+| ![](../image/retropad/retro_l1.png)            | X                            |
+| ![](../image/retropad/retro_r1.png)            | Z                            |
+
+## External links
+
+- [Official ClownMDEmu Website](https://clownmdemu.clownacy.com)
+- [Official ClownMDEmu GitHub Repository](https://github.com/Clownacy/clownmdemu-libretro)
+- [Libretro ClownMDEmu Core info file](https://github.com/libretro/libretro-super/blob/master/dist/info/clownmdemu_libretro.info)
+- [Report Libretro ClownMDEmu Core Issues Here](https://github.com/Clownacy/clownmdemu-libretro/issues)
+
+## Sega Mega Drive/Genesis cores
+
+- [Sega - Mega Drive - Genesis (BlastEm)](blastem.md)
+- [Sega - MS/GG/MD/CD (Genesis Plus GX)](genesis_plus_gx.md)
+- [Sega - MS/MD/CD/32X (PicoDrive)](picodrive.md)

--- a/docs/meta/see-also.md
+++ b/docs/meta/see-also.md
@@ -151,6 +151,8 @@ This is a list of cores that are related to each other in some way.
 - [Sega - Master System (Emux SMS)](../library/emux_sms.md)
 - [Sega - MS/GG/MD/CD (Genesis Plus GX)](../library/genesis_plus_gx.md)
 - [Sega - MS/MD/CD/32X (PicoDrive)](../library/picodrive.md)
+- [Sega - MD/CD (BlastEm)](../library/blastem.md)
+- [Sega - MD/CD (ClownMDEmu)](../library/clownmdemu.md)
 - [Sega - MS/GG/SG-1000 (Gearsystem)](../library/gearsystem.md)
 - [Sega - MS/GG (SMS Plus GX)](../library/smsplus.md)
 - [MSX/SVI/ColecoVision/SG-1000 (blueMSX)](../library/bluemsx.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -249,6 +249,7 @@ nav:
         - 'Sega - MS/GG/MD/CD (Genesis Plus GX)': 'library/genesis_plus_gx.md'
         - 'Sega - MS/MD/CD/32X (PicoDrive)': 'library/picodrive.md'
         - 'Sega - MD/CD (BlastEm)': 'library/blastem.md'
+        - 'Sega - MD/CD (ClownMDEmu)': 'library/clownmdemu.md'
         - 'Sega - Saturn (Beetle Saturn)': 'library/beetle_saturn.md'
         - 'Sega - Saturn/ST-V (Kronos)': 'library/kronos.md'
         - 'Sega - Saturn (Yabause)': 'library/yabause.md'


### PR DESCRIPTION
Also added BlastEm to the 'see also' list, since it was missing.

See also https://github.com/libretro/libretro-super/pull/1917.