### PR TITLE
Improve the core template and ClownMDEmu's documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ These are the documents that should be added/updated when a new core is added to
 
 - Add the core to docs/library/ (Follow the latest core template. docs/meta/core-template.md)
 - Add the core to mkdocs.yml
-- Add the core to docs/meta/core-list.md
+- Add the core to docs/guides/core-list.md
 - Add the core to docs/meta/see-also.md if it's related to another core in some way
 - Add the core to docs/development/licenses.md
 - Add the core to docs/guides/softpatching.md if it supports softpatching

--- a/docs/guides/retroachievements.md
+++ b/docs/guides/retroachievements.md
@@ -284,7 +284,7 @@ You can also check the progress of your friends and add comments on their trophi
 |----------------------------------------------------------------|:---------:|:------|
 | [Genesis Plus GX](https://github.com/libretro/Genesis-Plus-GX) | ✔         | Preferred core. |
 | [BlastEm](https://github.com/libretro/blastem)                 | ✕         | Cycle accurate. Genesis/MegaDrive only. Has known issues with game RAM and is incompatible with achievements. |
-| [ClownMDEmu](https://github.com/Clownacy/clownmdemu-libretro)  | ✕         |       |
+| [ClownMDEmu](https://github.com/Clownacy/clownmdemu-libretro)  | ✔         |       |
 | [Picodrive](https://github.com/libretro/picodrive)             | ✔         |       |
 | [SMS Plus GX](https://github.com/libretro/smsplus-gx)          | ✔         | Master System only |
 | [Gearsystem](https://github.com/drhelius/Gearsystem)           | ✔         | Master System only |
@@ -321,7 +321,7 @@ You can also check the progress of your friends and add comments on their trophi
 | Core                                                           | Supported | Notes |
 |----------------------------------------------------------------|:---------:|:------|
 | [Genesis Plus GX](https://github.com/libretro/Genesis-Plus-GX) | ✔         |       |
-| [ClownMDEmu](https://github.com/Clownacy/clownmdemu-libretro)  | ✕         |       |
+| [ClownMDEmu](https://github.com/Clownacy/clownmdemu-libretro)  | ✔         |       |
 | [Picodrive](https://github.com/libretro/picodrive)             | ✔         |       |
 
 #### Saturn

--- a/docs/library/clownmdemu.md
+++ b/docs/library/clownmdemu.md
@@ -41,7 +41,7 @@ Frontend-level settings or features that the ClownMDEmu core respects:
 | Rewind            | ✔         |
 | Netplay           | ✔         |
 | Core Options      | ✔         |
-| RetroAchievements | ✕         |
+| RetroAchievements | ✔         |
 | RetroArch Cheats  | ✕         |
 | Native Cheats     | ✕         |
 | Controls          | ✔         |

--- a/docs/library/clownmdemu.md
+++ b/docs/library/clownmdemu.md
@@ -206,6 +206,8 @@ The ClownMDEmu core has the following option(s) that can be tweaked from the cor
 
 ## Joypad
 
+![](../image/controller/md6.png)
+
 | RetroPad Inputs                                | User 1 - 2 input descriptors |
 |------------------------------------------------|------------------------------|
 | ![](../image/retropad/retro_b.png)             | B                            |

--- a/docs/library/clownmdemu.md
+++ b/docs/library/clownmdemu.md
@@ -34,7 +34,7 @@ RetroArch database(s) that are associated with the ClownMDEmu core:
 Frontend-level settings or features that the ClownMDEmu core respects:
 
 | Feature           | Supported |
-|-------------------|-----------|
+|-------------------|:---------:|
 | Restart           | ✔         |
 | Saves             | ✔         |
 | States            | ✔         |
@@ -68,14 +68,14 @@ The ClownMDEmu core saves/loads to/from these directories.
 **Frontend's Save directory**
 
 | File  | Description                  |
-|-------|------------------------------|
+|:-----:|:----------------------------:|
 | *.srm | Mega Drive/Genesis save data |
 | *.brm | Mega CD/Sega CD save data    |
 
 **Frontend's State directory**
 
 | File     | Description |
-|----------|-------------|
+|:--------:|:-----------:|
 | *.state# | State       |
 
 ## Geometry and timing

--- a/docs/meta/core-template.md
+++ b/docs/meta/core-template.md
@@ -268,6 +268,7 @@ Rumble only works in the [Core name] core when
 
 ## Joypad
 
+- // Illustrations are available in 'docs/image/controller', which may be useful here
 - // Add RetroPad inputs, please note the third column is only used when an input doesn't have a descriptor
 
 | RetroPad Inputs                                | User # input descriptors | (Device name) Inputs      |
@@ -492,7 +493,7 @@ Rumble only works in the [Core name] core when
 - // Or write up a compatibility description
 - // Or make a compatibility table
 
-## External Links
+## External links
 
 - // Put relevant links here
 
@@ -504,5 +505,4 @@ Rumble only works in the [Core name] core when
 
 ## (Related cores)
 
-- // Add links to related core docs here. Use the See Also doc for help
-- // https://docs.libretro.com/meta/see_also
+- // Add links to related core docs here. Use the 'docs/meta/see-also.md' doc for help


### PR DESCRIPTION
The issues with the core template were things which I noticed whilst using it to create my core's documentation, so correcting these should make it easier for people to produce good core documentation in the future.