### PR TITLE
Update cheat support status in fmsx.md

### DIFF
--- a/docs/library/fmsx.md
+++ b/docs/library/fmsx.md
@@ -64,8 +64,8 @@ RetroArch-level settings or features that the fMSX core respects.
 | Netplay           | ✔         |
 | Core Options      | ✔         |
 | [Memory Monitoring (achievements)](../guides/memorymonitoring.md) | ✔         |
-| RetroArch Cheats  | ✕         |
-| Native Cheats     | ✕         |
+| RetroArch Cheats  | ✔         |
+| Native Cheats     | ✔         |
 | Controls          | ✔         |
 | Remapping         | ✔         |
 | Multi-Mouse       | ✕         |


### PR DESCRIPTION
- Updating documentation that fmsx libretro core already supports cheats
- Only tested with MSX1/MSX2 games
- Updated cheat files and documentation is PR'd to core repo:  https://github.com/libretro/fmsx-libretro/pull/131