### PR TITLE
Update controller-autoconfiguration.md: All DualSense controller versions share the same USB PID unlike the earlier DualShock 4

### DIFF
--- a/docs/guides/controller-autoconfiguration.md
+++ b/docs/guides/controller-autoconfiguration.md
@@ -566,6 +566,8 @@ input_device_display_name_alt2 = "Sony Computer Entertainment Wireless (DualShoc
 | 6.2.0 | Yes | Yes | Sony Interactive Entertainment DualSense Wireless Controller | Yes | DualSense Wireless Controller | |
 | 6.8.0 | Yes | Yes | Sony Interactive Entertainment DualSense Wireless Controller | Yes | DualSense Wireless Controller | |
 
+It should be noted that all DualSense controller revisions (V1–V5) share the same USB PID 0CE6 under VID 054C, unlike the earlier DualShock 4, whose V1 and V2 models use distinct PIDs.
+
 In the above list, the following entries under **Autoconfigs file names to generate** are identified and required for the controller to be identified by linuxraw:
 
 ##### udev

--- a/docs/guides/controller-autoconfiguration.md
+++ b/docs/guides/controller-autoconfiguration.md
@@ -566,7 +566,8 @@ input_device_display_name_alt2 = "Sony Computer Entertainment Wireless (DualShoc
 | 6.2.0 | Yes | Yes | Sony Interactive Entertainment DualSense Wireless Controller | Yes | DualSense Wireless Controller | |
 | 6.8.0 | Yes | Yes | Sony Interactive Entertainment DualSense Wireless Controller | Yes | DualSense Wireless Controller | |
 
-It should be noted that all DualSense controller revisions (V1–V5) share the same USB PID 0CE6 under VID 054C, unlike the earlier DualShock 4, whose V1 and V2 models use distinct PIDs.
+
+It should be noted that all DualSense controller versions (V1–V5, regardless of firmware version) share the same USB PID 0CE6 under VID 054C, unlike the earlier DualShock 4, whose V1 and V2 models use distinct PIDs.
 
 In the above list, the following entries under **Autoconfigs file names to generate** are identified and required for the controller to be identified by linuxraw:
 


### PR DESCRIPTION
It should be noted that all DualSense controller versions (V1–V5, regardless of firmware version) share the same USB PID 0CE6 under VID 054C, unlike the earlier DualShock 4, whose V1 and V2 models use distinct PIDs.