### PR TITLE
pd777: add pd777 for epoch cassette vision

### DIFF
--- a/docs/development/licenses.md
+++ b/docs/development/licenses.md
@@ -179,6 +179,7 @@ See below for a summary of the licenses behind RetroArch and its cores:
 | PCem                                                                             | [GPLv2](https://github.com/libretro/libretro-pcem/blob/master/COPYING)                    |                |
 | [PCSX ReARMed](../library/pcsx_rearmed.md)                                       | [GPLv2](https://github.com/libretro/pcsx_rearmed/blob/master/COPYING)                     |                |
 | PCSX ReARMed [Interpreter]                                                       | [GPLv2](https://github.com/libretro/pcsx_rearmed/blob/master/COPYING)                     |                |
+| [PD777](../library/pd777.md)                                               | [MIT](https://github.com/mittonk/PD777/blob/main/LICENSE)                |                |
 | [PicoDrive](../library/picodrive.md)                                             | [MAME (Non-commercial)](https://github.com/libretro/picodrive/blob/master/COPYING)        | Non-commercial |
 | [PocketCDG](../library/pocketcdg.md)                                             | [MIT](https://github.com/libretro/libretro-pocketcdg/blob/master/LICENSE)                 |                |
 | [PokeMini](../library/pokemini.md)                                               | [GPLv3](https://github.com/libretro/PokeMini/blob/master/LICENSE)                         |                |

--- a/docs/guides/core-list.md
+++ b/docs/guides/core-list.md
@@ -162,6 +162,7 @@
 | PCem                      | IBM PC                 |                    |
 | [LRPS2](https://docs.libretro.com/library/lrps2/)               | Sony PlayStation 2     |                    |
 | [PCSX ReARMed](https://docs.libretro.com/library/pcsx_rearmed/) | Sony PlayStation       |                    |
+| [PD777](../library/pd777.md) | Epoch Cassette Vision |                    |
 | PicoDrive                 | Sega MS/GG/MD/CD/32X   |                    |
 | Play!                     | Sony PlayStation 2     |                    |
 | Pocket CDG                | Karaoke player         | A karaoke music player, ported to libretro |

--- a/docs/library/pd777.md
+++ b/docs/library/pd777.md
@@ -1,0 +1,150 @@
+# Epoch - Cassette Vision (PD777)
+
+## Background
+
+μPD777 is an emulator for the Epoch Cassette Vision, from Japan in 1981.
+It was one of the first Japanese consoles with interchangeable cartridges, but
+included a full CPU in each cartridge --- the console base was mostly buttons
+and wires.
+
+The Cassette Vision Jr (1983) used the same software, but dropped the paddle controls.
+
+PD777 is a Libretro port, to run in RetroArch.
+
+
+The PD777 core has been authored by:
+
+- W88DodPECuThLOl (Standalone PD777)
+- Ken Mitton
+
+The PD777 core is licensed under:
+
+- [MIT](https://github.com/mittonk/PD777/blob/main/LICENSE)
+
+A summary of the licenses behind RetroArch and its cores can be found [here](../development/licenses.md).
+
+## Requirements
+
+Minimal.
+
+## How to start the PD777 core:
+
+ROM file handling is currently awkward, but gives some options that work.
+
+1. Supply a .bin777 file to load; the core looks for a similarly-named .ptn777 file in the same directory.
+2. If that fails, run the content compiled from core/rom.cpp (as in standalone emulator).
+
+## BIOS
+
+None.
+
+## Extensions
+
+Content that can be loaded by the PD777 core have the following file extensions:
+
+- .bin777
+
+RetroArch database(s) that are associated with the PD777 core:
+
+- None yet
+
+## Features
+
+Frontend-level settings or features that the PD777 core respects:
+
+| Feature           | Supported |
+|-------------------|:---------:|
+| Restart           | ✔         |
+| Saves             | ✕         |
+| States            | ✕         |
+| Rewind            | ✕         |
+| Netplay           | ✕         |
+| Core Options      | ✔         |
+| [Memory Monitoring (achievements)](../guides/memorymonitoring.md) | ✕         |
+| RetroArch Cheats  | ✕         |
+| Native Cheats     | ✕         |
+| Controls          | ✔         |
+| Remapping         | ✔         |
+| Multi-Mouse       | ✕         |
+| Rumble            | ✕         |
+| Sensors           | ✕         |
+| Camera            | ✕         |
+| Location          | ✕         |
+| Subsystem         | ✕         |
+| [Softpatching](../guides/softpatching.md) | ✕         |
+| Disk Control      | ✕         |
+| Username          | ✕         |
+| Language          | ✔         |
+| Crop Overscan     | ✕         |
+| LEDs              | ✕         |
+
+## Directories
+
+None.
+
+## Geometry and timing
+
+- The PD777 core's core provided FPS is 60.
+- The PD777 core's core provided sample rate is 48000/00 Hz.
+- The PD777 core's base width is 375.
+- The PD777 core's base height is 240.
+- The PD777 core's core provided aspect ratio is 4:3.
+375x240, 60 FPS.
+
+## Usage
+
+Standard.
+
+## Core options
+
+None yet.
+
+## User 1 device types
+
+The PD777 core supports the following device type(s) in the controls menu, bolded device types are the default for the specified user(s):
+
+- **RetroPad**
+- RetroPad w/Analog
+- Mouse
+
+## Joypad
+
+The controls were built into the base unit, and some 2-player games assign buttons asymmetrically; for example, New Baseball gives most of the buttons to the fielding player, with just Lever Switch 1 for the batting player.
+
+| RetroPad Inputs                                | User # input descriptors | (Device name) Inputs      |
+|------------------------------------------------|--------------------------|---------------------------|
+| ![](../image/retropad/retro_b.png)             | Push2                    | -                         |
+| ![](../image/retropad/retro_y.png)             | Push3                    | -                         |
+| ![](../image/retropad/retro_select.png)        | Select                   | -                         |
+| ![](../image/retropad/retro_start.png)         | Start                    | -                         |
+| ![](../image/retropad/retro_dpad_up.png)       | Course Select increment  | -                         |
+| ![](../image/retropad/retro_dpad_down.png)     | Course Select decrement  | -                         |
+| ![](../image/retropad/retro_dpad_left.png)     | Lever Switch 1 Left      | -                         |
+| ![](../image/retropad/retro_dpad_right.png)    | Lever Switch 1 Right     | -                         |
+| ![](../image/retropad/retro_a.png)             | Push4                    | -                         |
+| ![](../image/retropad/retro_x.png)             | Push1                    | -                         |
+| ![](../image/retropad/retro_l1.png)            |                          | -                         |
+| ![](../image/retropad/retro_r1.png)            | AUX                      | -                         |
+| ![](../image/retropad/retro_l2.png)            |                          | -                         |
+| ![](../image/retropad/retro_r2.png)            |                          | -                         |
+| ![](../image/retropad/retro_l3.png)            |                          | -                         |
+| ![](../image/retropad/retro_r3.png)            |                          | -                         |
+| ![](../image/retropad/retro_left_stick.png) X  | Paddle 2                 | -                         |
+| ![](../image/retropad/retro_left_stick.png) Y  | Paddle 1                 | -                         |
+| ![](../image/retropad/retro_right_stick.png) X |                          | -                         |
+| ![](../image/retropad/retro_right_stick.png) Y |                          | -                         |
+
+RetroPad 2 gets Lever Switch 2 and Paddles 3 and 4.
+
+## External Links
+
+- [Standalone PD777 Repository](https://github.com/W88DodPECuThLOl/PD777)
+- [Libretro PD777 Core info file](https://github.com/libretro/libretro-super/blob/master/dist/info/pd777.info)
+- [Libretro PD777 (Website name)
+  Repository](https://github.com/mittonk/PD777)
+- [Report Libretro PD777 Core Issues
+  Here](https://github.com/mittonk/PD777/issues)
+
+## (Related cores)
+
+None.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -158,6 +158,9 @@ nav:
         - 'Enterprise 128 (ep128emu)': 'library/ep128emu.md'
       - 'Elektronika':
         - 'Elektronika - BK-0010/BK-0011 (bk)': 'library/bk.md'
+      - 'Epoch Emulation':
+        - 'Epoch - Cassette Vision (PD777)': 'library/pd777.md'
+        - 'Epoch - Super Cassette Vision (EmuSCV)': 'library/emuscv.md'
       - 'GCE Emulation':
         - 'GCE - Vectrex (vecx)': 'library/vecx.md'
       - 'Magnavox Emulation':
@@ -270,8 +273,6 @@ nav:
         - 'Sony - PlayStation 2 (PCSX2)': 'library/lrps2.md'
         - 'Sony - PlayStation 2 (Play!)': 'library/play.md'
         - 'Sony - PlayStation Portable (PPSSPP)': 'library/ppsspp.md'
-      - 'Super Cassette Vision':
-        - 'Super Cassette Vision (EmuSCV)': 'library/emuscv.md'
       - 'SpectraVision Emulation':
         - 'MSX/SVI/ColecoVision/SG-1000 (blueMSX)': 'library/bluemsx.md'
       - 'Texas Instruments Emulation':


### PR DESCRIPTION
First cut of docs for Epoch Cassette Vision emulator PD777.

The existing Super Cassette Vision emulator isn't namespaced by manufacturer --- moved it to a manufacturer category in `mkdocs.yml`, open to suggestions there.