### PR TITLE
Adjustments related to scan rework

### DIFF
--- a/docs/guides/arcade-getting-started.md
+++ b/docs/guides/arcade-getting-started.md
@@ -253,7 +253,7 @@ Time to find out how well your source ROMs matched up...
 
 ~~The RetroArch content database supports arcade romsets in Full Non-Merged and Split formats. In order to be recognized by the scanner, Full Non-Merged and Split romsets must also be [processed by TorrentZip to standardize their CRC](https://sourceforge.net/projects/trrntzip/).~~
 
-Manual scan is the recommended method for setting up arcade playlists in RetroArch. [Here](https://neo-source.com/index.php?topic=3725.0) is a guide written for creating FBNeo playlists, but you can easily adapt it for MAME usage.
+Custom scan with DAT file is the recommended method for setting up arcade playlists in RetroArch. [Here](https://neo-source.com/index.php?topic=3725.0) is a guide written for creating FBNeo playlists, but you can easily adapt it for MAME usage.
 
 !!! info "Credits"
     The arcade cabinets image is based on an image by Rob DiCaterino, licensed for reuse under a Creative Commons (CC BY 2.0) License. Original image and license: https://www.flickr.com/photos/goodrob13/17385639015/

--- a/docs/guides/databases.md
+++ b/docs/guides/databases.md
@@ -19,24 +19,22 @@ RetroArch uses the database to provide several automated cataloging functions:
 
 _See also: [Importing Content](https://docs.libretro.com/guides/import-content/) and [Creating Playlists](https://docs.libretro.com/guides/roms-playlists-thumbnails/#retroarch-playlist-scanner)._ 
 
-RetroArch's Import Content actions "Directory Scan" and "File Scan" will do the following:
+RetroArch's Import Content actions will do the following if strict (default) or loose database check is used:
 
 1. Compute a CRC checksum of the file(s) or scan for the in-game serial number. CRC and serial number are the [keys used for matching a game file to the database](#key-field-for-matching).
-1. Search for that CRC or serial in the information of the local `.rdb` files (default location `RetroArch/databases`). If the key is not found in databases, the file will __not__ be added to a playlist. See [Validation & Rejection](#validation-and-rejection).
+1. Search for that CRC or serial in the information of the local `.rdb` files (default location `RetroArch/databases`). If the key is not found in databases, the file will __not__ be added to a playlist in strict mode. See [Validation & Rejection](#validation-and-rejection).
 3. Assign the `Game Name` (aka display name or playlist item name) that is specified as `name` within the database entry for the key (CRC/serial). The assigned `Game Name` will appear in the playlist, instead of the filename.
 4. All other associated metadata [collated in the .rdb](https://github.com/libretro/libretro-database#fields-specified-in-game-information-databases) entry for the given CRC/serial can be viewed in the Information > Database Entry for the game and will be viewable via "Explore".
 
 ### Validation and Rejection
 
-Validation here refers to checking a file or attribute against a reference, and then accepting or rejecting it based on whether it matches what is specified in the reference data (aka what is "allowed").  RetroArch's "Scan Directory" and "Scan File" automated importers are validation processes, not merely tools for adding all files to a playlist.  Part of their function is to **reject** files, not to import all files.  The database is the reference, and the ROM file is the item being validated.
+Validation here refers to checking a file or attribute against a reference, and then accepting or rejecting it based on whether it matches what is specified in the reference data (aka what is "allowed").  RetroArch's strict scan is also a validation process, not merely a tool for adding all files to a playlist.  Part of the function is to **reject** certain files.  The database is the reference, and the ROM file is the item being validated.
 
-If your file's crc or internal serial data (whichever is the key used for matching, [see below](#key-field-for-matching)) does not exist in the database, the file will be rejected by the automatic scans and will not appear in the playlist.
-
-__Bypass validation and rejection.__  To import your games into a playlist regardless of database matches, or if your files are being rejected by the automatic scan (in other words are not recognized by the database) and you wish to add them to the playlist anyway, use the [Manual Scan](https://docs.libretro.com/guides/roms-playlists-thumbnails/#working-with-playlists).
+If your file's crc or internal serial data (whichever is the key used for matching, [see below](#key-field-for-matching)) does not exist in the database, the file will be rejected by the strict scans and will not appear in the playlist. By changing the Database Check parameter to Loose, such files will still be added to playlist.
 
 ### Key Field for Matching
 
-During [Playlist / Import Scanning](https://docs.libretro.com/guides/roms-playlists-thumbnails/#retroarch-playlist-scanner) ("Directory Scan" and "Scan File" in menu), RetroArch will identify your _files_ in order to then match your file to a data entry in the database.  The key for matching varies by console typical file size (i.e. original media type).
+During [Playlist / Import Scanning](https://docs.libretro.com/guides/roms-playlists-thumbnails/#retroarch-playlist-scanner), RetroArch will identify your _files_ in order to then match your file to a data entry in the database.  The key for matching varies by console original media type.
 
 - __CRC checksum__ for systems with smaller file sizes, e.g. games before the advent of disc-based consoles.
 - __Serial Number__ for larger files like disc-based games, to avoid computing checksums on large files. Found within the ROM file. The serial is not metadata but encoded within the game's binary data, which is scanned (in applicable cases) as a byte array by RetroArch.
@@ -65,9 +63,9 @@ The information below is for Users who are interested in figuring out the cause 
 
 The most common user problems and solutions related to the database are:
 
-- __Missed files during import scan.__ I.e. automated Directory Scan or File Scan "misses" some files, meaning the files are not imported and do not appear in the playlist.  See [Validation & Rejection](#validation-and-rejection) above.
+- __Missed files during import scan.__ I.e. default strict scan "misses" some files, meaning the files are not imported and do not appear in the playlist.  See [Validation & Rejection](#validation-and-rejection) above.
     - Solution A: [Contribute to the database](#how-to-contribute-to-databases) with data for the files/games that are not yet covered by the database.
-    - Solution B: Use the __Manual Scan__ option, which will accept all files according to the chosen settings.
+    - Solution B: Use the __Loose__ option, which will accept all files according to the chosen settings.
 - __Game Name error or incorrect information__. E.g. A game file receives a wrong title inside the RetroArch playlist/interface.
     - Solution:
       - Follow the [investigation steps](#investigating-database-issues) below to find the `.dat` file that has the erroneous information, and [contribute a correction](#how-to-contribute-to-databases).

--- a/docs/guides/import-content.md
+++ b/docs/guides/import-content.md
@@ -12,7 +12,7 @@ In order to have RetroArch recognise your games, you need to have a database of 
 !!! note
     Certain releases of Retroarch (e.g. Windows), come with the database files out-of-the-box.
 
-From the RetroArch main menu select "Online Updater", then choose "Update Databases".
+From the RetroArch main menu select "Online Updater", then choose "Update Databases". Also update core info files.
 
 Wait for the download to finish.
 
@@ -23,17 +23,7 @@ The "Import Content" menu can be either in the "Playlists" > "Import Content" (d
 !!! note
     The location of this menu item can be toggled in "Settings" > "User Interface" > "Menu Item Visibility" > "Show 'Import Content'" and updating this from "Playlists Menu" to "Main Menu".
 
-Here you will see three options, "Scan Directory", "Scan File" and "Manual Scan".
-
-!!! note
-    "Scan Directory" and "Scan File" are sometimes refered to as "Auto Scan". These options can only recognise content that match the database.
-    Using the default settings, these scan options also need a coresponding core for the said content to be already added.
-
-***1) Scan Directory:*** for importing a collection of content. Using the file browser, navigate to the folder of the content collection and select **"Scan This Directory"**.
-    
-***2) Scan File:*** for importing a single file. Navigate to file and select it.
-    
-***3) Manual Scan:*** it scans based on content file names and does not require content to match the database.
+The default, fully automatic option for scanning is strict (requires the CRC checksum or disc serial of the content to match the database). Scanning can be customized in several ways, loose scans for example will add content that does not match the database.
 
 Please be patient while it scans. Large collections could take several minutes.
 

--- a/docs/guides/roms-playlists-thumbnails.md
+++ b/docs/guides/roms-playlists-thumbnails.md
@@ -30,16 +30,16 @@ Playlists are the lists of games and other content that can be generated automat
 
 RetroArch incorporates a ROM scanning system to automatically produce playlists. Each ROM that is scanned by the playlist generator is checked against a database of ROMs that are known to be good copies.
 
-In order for content to be correctly scanned, you must:
+To ensure that scanning can use all available information:
 
-  - Have a compatible core already downloaded and installed (note: Scan Without Core Match setting removes this requirement)
+  - Have a compatible core already downloaded and installed (or enable Scan Without Core Match during scanning)
   - Update `Core Info Files` via `Online Updater`
   - Update `Databases` via `Online Updater`
   - Restart RetroArch if any of the above was just done
 
-For a normal scan, the content must match existing databases from the [libretro-database README](https://github.com/libretro/libretro-database#retroarch-database). If those conditions are met but content is still not being added automatically to a playlist, consider submitting an issue report on [github](https://www.github.com/libretro/RetroArch/issues).
+The default fully automatic scan is strict, the content CRC checksum or disc serial must match existing databases from the [libretro-database](https://github.com/libretro/libretro-database?tab=readme-ov-file#libretro-database). If those conditions are met but content is still not being added automatically to a playlist, consider submitting an issue report on [github](https://www.github.com/libretro/RetroArch/issues).
 
-There is an option to do manual scan, which does not require a database, and just needs the file names to match. Results from the manual scan will be playable (as long as the respective core supports them), but may lack thumbnails and do not appear in the Explore menu.
+Scan conditions could be relaxed ("loose scan"). If there is no database match, the content is still playable (as long as the respective core supports them), but may lack thumbnails and do not appear in the Explore menu.
 
 ### Designating which core to use
 


### PR DESCRIPTION
RA side changes have landed: https://github.com/libretro/RetroArch/pull/18641

Updated instructions in line with the new Loose scan option. References to "Scan Directory", "Scan File", "Manual scan" and other menu items are updated to reflect the current UI.