### PR TITLE
Fix REminiscence license

### DIFF
--- a/docs/development/licenses.md
+++ b/docs/development/licenses.md
@@ -192,7 +192,7 @@ See below for a summary of the licenses behind RetroArch and its cores:
 | PX68k                                                                            | [kero_src.txt](https://github.com/libretro/px68k-libretro/blob/master/doc/kero_src.txt)   |                |                                                                                          |                |
 | [QuickNES](../library/quicknes.md)                                               | [GPLv2](https://github.com/kode54/QuickNES/blob/master/COPYING)                       |                |
 | [Redream (libretro fork)](../library/redream.md)                                 | [GPLv3](https://github.com/libretro/redream/blob/master/LICENSE.txt)                      |                |
-| [REminiscence](../library/reminiscence.md)                                       | GPLv3                                                                                     |                |
+| [REminiscence](../library/reminiscence.md)                                       | (unclear open-source license)                                                             |                |
 | RemoteJoy                                                                        | [GPLv2](https://github.com/libretro/libretro-remotejoy/blob/master/LICENSE)               |                |
 | Remote RetroPad                                                                  | [MIT](https://github.com/libretro/libretro-samples/blob/master/license)                   |                |
 | [RVVM](../library/rvvm.md)                                                       | [GPLv3](https://github.com/LekKit/RVVM/blob/staging/LICENSE-GPL), [MPLv2.0](https://github.com/LekKit/RVVM/blob/staging/LICENSE-MPL) |                |

--- a/docs/library/reminiscence.md
+++ b/docs/library/reminiscence.md
@@ -19,7 +19,7 @@ The REminiscence core has been authored by
 
 The REminiscence core is licensed under
 
-- GPLv3
+- (unclear open-source license)
 
 A summary of the licenses behind RetroArch and its cores can be found [here](../development/licenses.md).
 


### PR DESCRIPTION
The [original REminiscence code](https://github.com/cyxx/REminiscence) is not published under a specified license; the only licensing information in any of its files is a header comment reading "Copyright [years] Gregory Montoir" in some of the files. This is also true of the other reverse-engineered ports by this author. I have not been able to find mention of any specific license anywhere in the REminiscence code.

As such I don't think the REminiscence libretro core can be licensed as GPLv3 (and notably [the core repo itself](https://github.com/libretro/REminiscence) does not contain a license file either, so I don't think it actually *is*, making the information in the documentation here just incorrect).

While the original port's author was evidently okay with his code being built and redistributed by others (he links to a number of third-party homebrew console ports on his website), I think the actual licensing information on the code would need to be interpreted as an "all rights reserved" type clause rather than a copyleft license (let alone something more permissive).

I have been trying to contact the original reverse-engineered port's author to try and clarify the licensing status of any of their work and will submit a new PR with updated information if I manage to reach them and get clarification.