### PR TITLE
Remove Doom reshack mention

### DIFF
--- a/docs/library/compatibility/jaguar.md
+++ b/docs/library/compatibility/jaguar.md
@@ -7,7 +7,6 @@ A reference compatibility table can be found here [https://icculus.org/virtualja
 | Game               | Issue                                                   |
 |--------------------|-------------------------------------------------------- |
 | Cybermorph         | Graphics glitches.                                      |
-| Doom               | Enable Doom core option hack for proper graphics pitch. |
 | Iron Soldier       | Hangs after selecting a stage.                          |
 | Iron Soldier 2     | Hangs after selecting a stage. Audio glitches.          |
 | Kasumi Ninja       | Graphics glitches. Missing background layers            |


### PR DESCRIPTION
no longer needed since Virtual Jaguar [2.2.0](https://github.com/libretro/virtualjaguar-libretro/releases/tag/v2.2.0)