### PR TITLE
Fix FFmpeg core documentation links

### DIFF
--- a/docs/guides/core-list.md
+++ b/docs/guides/core-list.md
@@ -82,7 +82,7 @@
 | FB Alpha 2012 Neo Geo     | Neo Geo                |                    |
 | [FB Neo](../library/fbneo.md)  | Arcade/Console/various | Full list of supported systems: https://github.com/finalburnneo/FBNeo/wiki |
 | [FCEUmm](../library/fceumm.md) | Nintendo NES/Famicom   |                    |
-| FFmpeg                    | Media player           | A port of FFmpeg library which allows playback of a variety of audio and video formats |
+| [FFmpeg](../library/ffmpeg.md) | Media player      | Plays common video and audio formats through the FFmpeg libretro core |
 | fixGB                     | Game Boy/Color         |                    |
 | fixNES                    | Nintendo NES/Famicom   |                    |
 | Flycast                   | Sega Dreamcast/NAOMI   |                    |

--- a/docs/library/ffmpeg.md
+++ b/docs/library/ffmpeg.md
@@ -24,7 +24,7 @@ A summary of the licenses behind RetroArch and its cores can be found [here](../
 
 ### Watching Movies with Subtitles
 
-You can open video files in the following formats(see: [Extensions](../ffmpeg/#extensions)). If your video file in these formats has a subtitle file encoded with .SSA type, these subtitle files will appear automatically. External subtitles are currently not supported. The video files you have played will be added to the Videos section in the main menu.
+You can open video files in the following formats (see: [Extensions](#extensions)). If your video file in these formats has a subtitle file encoded with .SSA type, these subtitle files will appear automatically. External subtitles are currently not supported. The video files you have played will be added to the Videos section in the main menu.
 
 ??? note "Turkish subtitles encoded 95's Ghost in the Shell"
 	![RetroArch and LibRetro do not share any copyrighted content.](../image/core/ffmpeg/subtitle.png)
@@ -37,7 +37,7 @@ Watch the video below for details:
 
 ### Listening to Music
 
-You can open audio files in the following formats (see: [Extensions](../ffmpeg/#extensions)). In the example below, you can see and listen to an mp3 file running at the lowest settings. File quality will affect sound quality. The audio files you have played will be added to the Music section in the main menu.
+You can open audio files in the following formats (see: [Extensions](#extensions)). In the example below, you can see and listen to an mp3 file running at the lowest settings. File quality will affect sound quality. The audio files you have played will be added to the Music section in the main menu.
 
 ??? note "Example"
 	<video width="320" height="240" controls>
@@ -93,7 +93,7 @@ Frontend-level settings or features that the FFmpeg core respects.
 |-------------------|:---------:|
 | Restart           | ✔         |
 | Screenshots       | ✔         |
-| [Shaders](../ffmpeg/#shaders)       | ✔         |
+| [Shaders](#shaders)       | ✔         |
 | Saves             | ✕         |
 | States            | ✕         |
 | Rewind            | ✕         |
@@ -123,9 +123,9 @@ The FFmpeg core's directory name is 'FFmpeg'
 
 ### Geometry and timing
 
-- The FFmpeg core's core provided FPS is dependant on the loaded media.
-- The FFmpeg core's core provided sample rate is dependant on the loaded media.
-- The FFmpeg core's core provided aspect ratio is dependant on the loaded media.
+- The FFmpeg core's core provided FPS is dependent on the loaded media.
+- The FFmpeg core's core provided sample rate is dependent on the loaded media.
+- The FFmpeg core's core provided aspect ratio is dependent on the loaded media.
 
 ### Shaders
 


### PR DESCRIPTION
## Summary

Small documentation cleanup related to libretro core documentation coverage.

- Link the FFmpeg entry in the core list to its existing library page.
- Fix stale self-links in `docs/library/ffmpeg.md` so they point to the local sections.
- Correct `dependant` -> `dependent` in the FFmpeg geometry/timing section.

## Verification

```bash
git diff --check
rg -n "\.\.\/ffmpeg|dependant|formats\(" docs/library/ffmpeg.md docs/guides/core-list.md
```

Related bounty issue: libretro/libretro-meta#79
