### PR TITLE
Add Native32Emu core documentation

### DIFF
--- a/docs/development/licenses.md
+++ b/docs/development/licenses.md
@@ -168,6 +168,7 @@ See below for a summary of the licenses behind RetroArch and its cores:
 | [Mr.Boom](../library/mr_boom.md)                          		           | [MIT](https://github.com/libretro/mrboom-libretro/blob/master/LICENSE)                    |                |
 | Mupen64Plus                                               		           | [GPLv3](https://github.com/libretro/mupen64plus-libretro/blob/master/LICENSE)             |                |
 | Mupen64Plus GLES3                                         		           | [GPLv3](https://github.com/libretro/mupen64plus-libretro/blob/master/LICENSE)             |                |
+| [Native32Emu](../library/native32emu.md)                                         | [BSD-3-Clause](https://github.com/jiangxincode/Native32Emu/blob/master/LICENSE)           |                |
 | Neko Project II                                           		           |                                                                                           |                |
 | Neko Project II Kai                                                              | [MIT](https://github.com/AZO234/NP2kai/blob/master/LICENSE)                               |                |
 | [Nestopia](../library/nestopia.md)                                               | [GPLv2](https://github.com/libretro/nestopia/blob/master/COPYING)                         |                |

--- a/docs/guides/core-list.md
+++ b/docs/guides/core-list.md
@@ -147,6 +147,7 @@
 | [Mupen64Plus-Next](https://docs.libretro.com/library/mupen64plus/)          | Nintendo 64            |                    |
 | [Mupen64Plus-Next GLES2](https://docs.libretro.com/library/mupen64plus/)    | Nintendo 64            |                    |
 | [Mupen64Plus-Next GLES3](https://docs.libretro.com/library/mupen64plus/)    | Nintendo 64            |                    |
+| [Native32Emu](../library/native32emu.md) | Sunplus Native32 | An emulator for the Sunplus Native32 game format used by DVD player and TV chipsets |
 | Neko Project II           | NEC PC-98              |                    |
 | Neko Project II Kai       | NEC PC-98              |                    |
 | NeoCD                     | Neo Geo CD             |                    |

--- a/docs/library/native32emu.md
+++ b/docs/library/native32emu.md
@@ -1,0 +1,94 @@
+# Native32 (Native32Emu)
+
+## Background
+
+Native32 is a game format developed by Sunplus for DVD player and TV chipsets (circa 2005–2011). Games use `.smf`, `.sgm`, or `.ssl` file extensions and feature a stack-based, ActionScript-like virtual machine with raster graphics. Native32Emu is an emulator for this format written in Rust, with a libretro core front-end.
+
+The Native32Emu core has been authored by:
+
+- Aloys
+
+The Native32Emu core is licensed under:
+
+- [BSD-3-Clause](https://github.com/jiangxincode/Native32Emu/blob/master/LICENSE)
+
+A summary of the licenses behind RetroArch and its cores can be found [here](../development/licenses.md).
+
+## BIOS
+
+No BIOS or firmware files are required.
+
+## Extensions
+
+Content that can be loaded by the Native32Emu core have the following file extensions:
+
+- .smf
+- .sgm
+- .ssl
+
+RetroArch database(s) that are associated with the Native32Emu core:
+
+- Native32
+
+## Features
+
+Frontend-level settings or features that the Native32Emu core respects:
+
+| Feature           | Supported |
+|-------------------|:---------:|
+| Restart           | ✔         |
+| Saves             | ✕         |
+| States            | ✕         |
+| Rewind            | ✕         |
+| Netplay           | ✕         |
+| Core Options      | ✕         |
+| [Memory Monitoring (achievements)](../guides/memorymonitoring.md) | ✕         |
+| RetroArch Cheats  | ✕         |
+| Native Cheats     | ✕         |
+| Controls          | ✔         |
+| Remapping         | ✔         |
+| Multi-Mouse       | ✕         |
+| Rumble            | ✕         |
+| Sensors           | ✕         |
+| Camera            | ✕         |
+| Location          | ✕         |
+| Subsystem         | ✕         |
+| [Softpatching](../guides/softpatching.md) | ✕         |
+| Disk Control      | ✕         |
+| Username          | ✕         |
+| Language          | ✕         |
+| Crop Overscan     | ✕         |
+| LEDs              | ✕         |
+
+## Directories
+
+The Native32Emu core's library name is 'Native32 (Native32Emu)'
+
+## Usage
+
+The Native32Emu core requires the full path to content (it loads sibling files for `.ssl` multi-file content), so content is loaded directly from disk rather than from memory.
+
+Video is output in the XRGB8888 pixel format and audio is output as stereo. Audio is currently limited to RAW PCM; MP3 music is not yet played. Save states and core options are not yet implemented.
+
+## User 1 device types
+
+The Native32Emu core supports the following device type(s) in the controls menu, bolded device types are the default for the specified user(s):
+
+- **RetroPad** - Gamepad
+
+## Joypad
+
+| RetroPad Inputs                                | User 1 input descriptors |
+|------------------------------------------------|--------------------------|
+| ![](../image/retropad/retro_b.png)             | A (Native32 keycode 0x4000) |
+| ![](../image/retropad/retro_a.png)             | B / Menu (Native32 keycode 0x8800) |
+| ![](../image/retropad/retro_dpad_up.png)       | Up                       |
+| ![](../image/retropad/retro_dpad_down.png)     | Down                     |
+| ![](../image/retropad/retro_dpad_left.png)     | Left                     |
+| ![](../image/retropad/retro_dpad_right.png)    | Right                    |
+
+## External links
+
+- [Native32Emu Repository](https://github.com/jiangxincode/Native32Emu)
+- [Libretro Native32Emu Core info file](https://github.com/libretro/libretro-super/blob/master/dist/info/native32emu_libretro.info)
+- [Report Libretro Native32Emu Core Issues Here](https://github.com/jiangxincode/Native32Emu/issues)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -279,6 +279,8 @@ nav:
         - 'Sony - PlayStation Portable (PPSSPP)': 'library/ppsspp.md'
       - 'SpectraVision Emulation':
         - 'MSX/SVI/ColecoVision/SG-1000 (blueMSX)': 'library/bluemsx.md'
+      - 'Sunplus Emulation':
+        - 'Sunplus - Native32 (Native32Emu)': 'library/native32emu.md'
       - 'Texas Instruments Emulation':
         - 'Texas Instruments - TI-83 (Numero)': 'library/numero.md'
       - 'Thomson Emulation':


### PR DESCRIPTION
## Summary

Adds documentation for the **Native32Emu** libretro core, following the [adding a new core](https://github.com/libretro/docs#adding-a-new-core) instructions.

Native32Emu emulates the Native32 game format developed by Sunplus for DVD player and TV chipsets (circa 2005–2011). Games use `.smf`, `.sgm`, and `.ssl` extensions. The core is written in Rust and licensed BSD-3-Clause.

- Core source: https://github.com/jiangxincode/Native32Emu
- Core info file PR (libretro-super): https://github.com/libretro/libretro-super/pull/1982

## Changes

Per the new-core checklist:

- **Added** `docs/library/native32emu.md` — the core documentation page, based on `docs/meta/core-template.md` (background, license, extensions, features table, controls, usage, external links).
- **Updated** `mkdocs.yml` — added a "Sunplus Emulation" entry under Core Library: Emulation pointing to the new page.
- **Updated** `docs/guides/core-list.md` — added the Native32Emu row (alphabetically under N).
- **Updated** `docs/development/licenses.md` — added the Native32Emu entry (BSD-3-Clause) in the Cores table.

## Notes

The checklist items that don't apply were skipped:
- No BIOS/firmware required, so no `docs/library/bios.md` entry.
- No softpatching support, so no `docs/guides/softpatching.md` entry.
- No RetroAchievements support, so no `docs/guides/retroachievements.md` entry.

A few features (MP3 audio, save states, core options) are still in progress; the features table reflects the current state. Happy to adjust any wording or placement to match project conventions.