### PR TITLE
Psp go storage notes

### DIFF
--- a/docs/guides/install-psp.md
+++ b/docs/guides/install-psp.md
@@ -21,6 +21,12 @@ You can download a bundle with the **Stable** version of RetroArch, all the supp
 
 Installation is also very simple. Just create a `RetroArch` folder under `PSP/Game` directory on your Memory Stick and transfer the archive files to the `PSP/Game/RetroArch` folder, then go to `Memory Stick™` under **Game** press **X**, and then select RetroArch. Press **X** again to open.
 
+!!! note
+  The PSP Go uses a Memory Stick Micro (M2) card slot instead of the full-size Memory Stick slot in addition to it's built-in internal storage (`ef0:`). You can install RetroArch to either storage location. An M2 card appears as `ms0:` like a regular PSPs memory stick, and the internal storage as `ef0:`. RetroArch stores its user data (config, saves, save states, system files) on the same drive it is installed to. Installing to internal storage keeps everything on `ef0:` without needing an M2 card.
+
+!!! warning
+  User data and libretro cores live on the drive RetroArch is installed to (`ms0:` or `ef0:`). RetroArch does not migrate data when you move it. If you relocate RetroArch to another drive you must copy your `PSP/RetroArch` and the `PSP/GAME/retroarch/cores` folder to the new drive and resolve any config conflicts yourself. Otherwise RetroArch will start with a fresh configuration.
+
 ### Updating
 
 Download the latest version and extract it into 'PSP/Game/RetroArch' on the Memory Stick. Accept when prompted to overwrite.

--- a/docs/guides/install-psp.md
+++ b/docs/guides/install-psp.md
@@ -22,10 +22,10 @@ You can download a bundle with the **Stable** version of RetroArch, all the supp
 Installation is also very simple. Just create a `RetroArch` folder under `PSP/Game` directory on your Memory Stick and transfer the archive files to the `PSP/Game/RetroArch` folder, then go to `Memory Stick™` under **Game** press **X**, and then select RetroArch. Press **X** again to open.
 
 !!! note
-  The PSP Go uses a Memory Stick Micro (M2) card slot instead of the full-size Memory Stick slot in addition to it's built-in internal storage (`ef0:`). You can install RetroArch to either storage location. An M2 card appears as `ms0:` like a regular PSPs memory stick, and the internal storage as `ef0:`. RetroArch stores its user data (config, saves, save states, system files) on the same drive it is installed to. Installing to internal storage keeps everything on `ef0:` without needing an M2 card.
+	The PSP Go uses a Memory Stick Micro (M2) card slot instead of the full-size Memory Stick slot in addition to its built-in internal storage (`ef0:`). You can install RetroArch to either storage location. An M2 card appears as `ms0:` like a regular PSP's memory stick, and the internal storage as `ef0:`. RetroArch stores its user data (config, saves, save states, system files) on the same drive it is installed to. Installing to internal storage keeps everything on `ef0:` without needing an M2 card.
 
 !!! warning
-  User data and libretro cores live on the drive RetroArch is installed to (`ms0:` or `ef0:`). RetroArch does not migrate data when you move it. If you relocate RetroArch to another drive you must copy your `PSP/RetroArch` and the `PSP/GAME/retroarch/cores` folder to the new drive and resolve any config conflicts yourself. Otherwise RetroArch will start with a fresh configuration.
+	User data and libretro cores live on the drive RetroArch is installed to (`ms0:` or `ef0:`). RetroArch does not migrate data when you move it. If you relocate RetroArch to another drive you must copy your `PSP/RetroArch` and the `PSP/GAME/retroarch/cores` folder to the new drive and resolve any config conflicts yourself. Otherwise RetroArch will start with a fresh configuration.
 
 ### Updating
 


### PR DESCRIPTION
This PR is the docs change from the fixes put in place on the PSP Go from libretro PR [19100](https://github.com/libretro/RetroArch/pull/19100).

Due to the change in how RetroArch looks for associated config files depending on where it is installed on the PSP Go the note and warning I added clarify this new logic should a user be confused.

For more information please see the linked PR.