### PR TITLE
Update tv.md: Add a HDMI-CEC Remote Control Pass-Through section

### DIFF
--- a/docs/guides/tv.md
+++ b/docs/guides/tv.md
@@ -51,7 +51,7 @@ Enabling this feature allows you to use your TV remote to control your Digital M
 
 ### The Problem: RetroArch Lockout
 
-While basic buttons like the arrows and OK key work perfectly in standard apps, they will fail inside RetroArch. Because the app lacks a configuration profile for your specific TV remote, it won't map the inputs correctly, resulting in a `Virtual (0/0) not configured, using fallback` error. If your Bluetooth controller disconnects, you will find yourself completely locked out of navigating the RetroArch menus.
+While standard navigation keys like **Arrows, OK, and Back/Exit** work flawlessly in regular apps, they fail inside RetroArch. Because the app lacks a configuration profile for your specific TV remote, it cannot map the inputs correctly—frequently triggering a `Virtual (0/0) not configured, using fallback` error. Consequently, if your Bluetooth controller disconnects, you are left completely stranded; the remote's **Arrows and OK** buttons cannot be used to navigate to **Main Menu → Quit**, and the **Back/Exit** buttons will fail to return you to the dashboard of the Digital Media Player.
 
 #### The Workaround
 

--- a/docs/guides/tv.md
+++ b/docs/guides/tv.md
@@ -35,6 +35,31 @@ For older TVs without a "Game" picture mode, use RetroArch's `Settings` → `Lat
 
 Shaders and overlays in RetroArch may be used instead of TV picture modes to apply authentic retro display effects and decorative elements directly to the emulated image, bypassing the hardware-dependent post-processing in non-Game picture modes that introduces input lag.
 
+## HDMI-CEC Remote Control Pass-Through
+
+> Note: This section is for Digital Media Players only. TV remotes cannot operate on PCs at all; even basic navigation commands will not function, as standard computer graphics cards do not support HDMI-CEC communication.
+
+Most modern Smart TVs include built-in HDMI-CEC hardware. To use it, you just need to turn on **HDMI-CEC Remote Control Pass-Through** in your TV’s settings (the exact name changes depending on the brand). 
+
+### **Supported Buttons via HDMI-CEC**
+
+Enabling this feature allows you to use your TV remote to control your Digital Media Player. Depending on your TV brand, the buttons will typically function as follows:
+
+* **Basic Navigation:** The physical **Arrows, OK, and Back/Exit** buttons.
+* **The Menu/Options Button:** Often labeled as **`...`** or **`123`**, this button brings up the TV's on-screen overlay. It adds a virtual **"HOME"** shortcut specifically for your digital media player.
+  - **Note:** This virtual shortcut is necessary because the physical **HOME** button on your remote is hardwired directly to the TV's own operating system and cannot communicate with your streaming device.
+
+### The Problem: RetroArch Lockout
+
+While basic buttons like the arrows and OK key work perfectly in standard apps, they will fail inside RetroArch. Because the app lacks a configuration profile for your specific TV remote, it won't map the inputs correctly, resulting in a `Virtual (0/0) not configured, using fallback` error. If your Bluetooth controller disconnects, you will find yourself completely locked out of navigating the RetroArch menus.
+
+#### The Workaround
+
+1. **Open the TV Menu:** Press your TV remote's Menu button to bring up the on-screen digital overlay.
+2. **Trigger the Virtual Home Button:** Select the virtual **"HOME"** shortcut from that overlay. This sends a command through the HDMI cable, forcing RetroArch to close and bringing you straight back to your streaming device's main dashboard.
+3. **Reconnect Your Controller:** Now that you are back on the main dashboard, your TV remote's arrow keys and OK button will work normally again. Use them to navigate to your device's Bluetooth settings and re-pair your gamepad.
+4. **Resume Playing:** Once your controller is connected, simply relaunch RetroArch and get back to your game.
+
 ## Frame rate fluctuations
 
 ### Frame rate fluctuations fix: Use RetroArch Synchronization features

--- a/docs/guides/tv.md
+++ b/docs/guides/tv.md
@@ -45,13 +45,13 @@ Most modern Smart TVs include built-in HDMI-CEC hardware. To use it, you just ne
 
 Enabling this feature allows you to use your TV remote to control your Digital Media Player. Depending on your TV brand, the buttons will typically function as follows:
 
-* **Basic Navigation:** The physical **Arrows, OK, and Back/Exit** buttons.
+* **Basic Navigation:** The physical **Arrows, OK, Back, and Exit** buttons.
 * **The Menu/Options Button:** Often labeled as **`...`** or **`123`**, this button brings up the TV's on-screen overlay. It adds a virtual **"HOME"** shortcut specifically for your digital media player.
   - **Note:** This virtual shortcut is necessary because the physical **HOME** button on your remote is hardwired directly to the TV's own operating system and cannot communicate with your streaming device.
 
 ### The Problem: RetroArch Lockout
 
-While standard navigation keys like **Arrows, OK, and Back/Exit** work flawlessly in regular apps, they fail inside RetroArch. Because the app lacks a configuration profile for your specific TV remote, it cannot map the inputs correctly—frequently triggering a `Virtual (0/0) not configured, using fallback` error. Consequently, if your Bluetooth controller disconnects, you are left completely stranded; the remote's **Arrows and OK** buttons cannot be used to navigate to **Main Menu → Quit**, and the **Back/Exit** buttons will fail to return you to the dashboard of the Digital Media Player.
+While standard navigation keys **Arrows, OK, Back, and Exit** work flawlessly in regular apps, they fail inside RetroArch. Because the app lacks a configuration profile for your specific TV remote, it cannot map the inputs correctly—frequently triggering a `Virtual (0/0) not configured, using fallback` error. Consequently, if your Bluetooth controller disconnects, you are left completely stranded; the remote's **Arrows and OK** buttons cannot be used to navigate to **Main Menu → Quit**, and the **Back** or **Exit** buttons will fail to return you to the dashboard of the Digital Media Player.
 
 #### The Workaround
 

--- a/docs/guides/tv.md
+++ b/docs/guides/tv.md
@@ -41,7 +41,7 @@ Shaders and overlays in RetroArch may be used instead of TV picture modes to app
 
 Most modern Smart TVs include built-in HDMI-CEC hardware. To use it, you just need to turn on **HDMI-CEC Remote Control Pass-Through** in your TV’s settings (the exact name changes depending on the brand). 
 
-### **Supported Buttons via HDMI-CEC**
+### Supported Buttons via HDMI-CEC
 
 Enabling this feature allows you to use your TV remote to control your Digital Media Player. Depending on your TV brand, the buttons will typically function as follows:
 


### PR DESCRIPTION
Complete rewrite of https://github.com/libretro/docs/pull/1147

Beyond its cleaner structure, this revision includes a crucial addition: it explains that while HDMI-CEC Remote Control Pass-Through **allows the Arrows, OK, Back, and Exit buttons to work normally in standard apps**, they fail inside RetroArch. This clarifies exactly why the workaround is necessary, detailing how to use the TV remote's physical Menu button to escape RetroArch since the standard Exit button does not function within the app.