### PR TITLE
Remove Cannonball from Sega Emulation

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -245,7 +245,6 @@ nav:
         - 'SNK - Neo Geo Pocket / Color (Beetle NeoPop)': 'library/beetle_neopop.md'
         - 'SNK - Neo Geo Pocket / Color (RACE)': 'library/race.md'
       - 'Sega Emulation':
-        - 'Cannonball': 'library/cannonball.md'
         - 'Sega - 32X Compatibility List': 'library/compatibility/32x.md'
         - 'Sega - Dreamcast Compatibility List': 'library/compatibility/dc.md'
         - 'Sega - Saturn Compatibility List': 'library/compatibility/saturn.md'


### PR DESCRIPTION
Removes Cannonball from Sega Emulation. Cannonball is already included under "Core Library: Game and Scripting Engines", Mentioning it under Sega Emulation doesn't make much sense since it's just an engine that plays Out Run and not an emulator.

This fixes #1152 