### PR TITLE
docs: Add RustyNES core documentation page

### DIFF
--- a/docs/library/rustynes.md
+++ b/docs/library/rustynes.md
@@ -1,4 +1,4 @@
-# RustyNES
+# Nintendo - NES / Famicom (RustyNES)
 
 ## Background
 

--- a/docs/library/rustynes.md
+++ b/docs/library/rustynes.md
@@ -1,0 +1,79 @@
+# RustyNES
+
+## Background
+
+RustyNES is a cycle-accurate Nintendo Entertainment System (NES) and Famicom emulator written entirely in pure Rust. It targets the highest accuracy bar (comparable to Mesen and higan) through strict lockstep timing at PPU-dot resolution, without relying on threading or standard library timing. 
+
+It is extremely portable and deterministic, making it a reliable choice for netplay, TAS, and accurate emulation enthusiasts.
+
+### Author/License
+
+The RustyNES core has been authored by
+- DoubleGate
+
+The RustyNES core is licensed under
+- MIT OR Apache-2.0
+
+A summary of the licenses behind RetroArch and its cores can be found [here](../development/licenses.md).
+
+## Extensions
+
+Content that can be loaded by the RustyNES core have the following file extensions:
+- .nes
+
+## Databases
+
+RetroArch database(s) that are associated with the RustyNES core:
+- Nintendo - Nintendo Entertainment System
+
+## Features
+
+Frontend-level settings or features that the RustyNES core respects.
+
+| Feature           | Supported |
+|-------------------|-----------|
+| Restart           | ✔         |
+| Screenshots       | ✔         |
+| Saves             | ✔         |
+| States            | ✔         |
+| Rewind            | ✔         |
+| Netplay           | ✔         |
+| Core Options      | ✕         |
+| RetroAchievements | ✔         |
+| RetroArch Cheats  | ✕         |
+| Native Cheats     | ✕         |
+| Controls          | ✔         |
+| Remapping         | ✔         |
+| Multi-Mouse       | ✕         |
+| Rumble            | ✕         |
+| Sensors           | ✕         |
+| Camera            | ✕         |
+| Location          | ✕         |
+| Subsystem         | ✕         |
+| Softpatching      | ✔         |
+| Disk Control      | ✕         |
+| Username          | ✕         |
+| Language          | ✕         |
+| Crop Overscan     | ✕         |
+| Active Touchpad   | ✕         |
+
+## Directories
+
+The RustyNES core's directory name is 'RustyNES'.
+
+### BIOS
+
+No BIOS files are strictly required to use the RustyNES core.
+
+## Joypad
+
+| User 1 - 2 input descriptors | RetroPad Inputs                           |
+|------------------------------|-------------------------------------------|
+| B                            | ![](../image/retropad/retro_b.png)        |
+| A                            | ![](../image/retropad/retro_a.png)        |
+| Select                       | ![](../image/retropad/retro_select.png)   |
+| Start                        | ![](../image/retropad/retro_start.png)    |
+| D-Pad Up                     | ![](../image/retropad/retro_dpad_up.png)  |
+| D-Pad Down                   | ![](../image/retropad/retro_dpad_down.png)|
+| D-Pad Left                   | ![](../image/retropad/retro_dpad_left.png)|
+| D-Pad Right                  | ![](../image/retropad/retro_dpad_right.png)|

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -195,6 +195,7 @@ nav:
         - 'Nintendo - GameCube/Wii (Dolphin)': 'library/dolphin.md'
         - 'Nintendo - NES (bnes)': 'library/bnes.md'
         - 'Nintendo - NES / Famicom (Emux NES)': 'library/emux_nes.md'
+        - 'Nintendo - NES / Famicom (RustyNES)': 'library/rustynes.md'
         - 'Nintendo - NES / Famicom (FCEUmm)': 'library/fceumm.md'
         - 'Nintendo - NES / Famicom (Mesen)': 'library/mesen.md'
         - 'Nintendo - NES / Famicom (Nestopia)': 'library/nestopia.md'


### PR DESCRIPTION
This PR adds the standard documentation page for the new RustyNES core and hooks it into the `mkdocs.yml` navigation tree under the Nintendo Entertainment System section.