### PR TITLE
Update EasyRPG Player core documentation

### DIFF
--- a/docs/library/easyrpg.md
+++ b/docs/library/easyrpg.md
@@ -94,7 +94,7 @@ The EasyRPG core saves/loads to/from these directories.
 
 - easyrpg-player/config.ini (configuration of the engine)
 - easyrpg-player/Soundfont (soundfont files)
-- easyrpg-player/Font (Font files)
+- easyrpg-player/Font (font files)
 - easyrpg-player/wildmidi.cfg (wildmidi configuration file, to combine with an instruments folder)
 
 ### Geometry and timing

--- a/docs/library/easyrpg.md
+++ b/docs/library/easyrpg.md
@@ -26,11 +26,12 @@ Content that can be loaded by the EasyRPG core have the following file extension
 
 - .ldb
 - .zip
+- .lzh
 - .easyrpg
 
 ### RTP files
 
-You must download the RTP2000 and RTP2003 from [here](https://www.rpgmakerweb.com/run-time-package). They are exe/zip files but can be extracted with e.g. 7zip. Create `rtp` folder in `system` folder. Put the extracted data in "rtp/2000" and "rtp/2003" to `system/rtp` accordingly.
+You must download the RTP2000 and RTP2003 from [here](https://www.rpgmakerweb.com/run-time-package). They are exe/zip files but can be extracted with e.g. 7zip. Create a `rtp` folder in the `system` folder of the frontend. Put the extracted data from the RTP2000 "rtp/2000" and the extracted data from the RTP2003 in "rtp/2003".
 
 |   |   |   |   |   |
 |---|---|---|---|---|
@@ -87,10 +88,14 @@ The EasyRPG core saves/loads to/from these directories.
 - Save##.dyn (Additional save file data used by some games)
 - Save.lgs (Global save data used by some games)
 - easyrpg_log.txt (EasyRPG log file)
+- Arbitrary files may be created in the game directory depending on the game
 
 **Frontend's system directory**
 
 - easyrpg-player/config.ini (configuration of the engine)
+- easyrpg-player/Soundfont (soundfont files)
+- easyrpg-player/Font (Font files)
+- easyrpg-player/wildmidi.cfg (wildmidi configuration file, to combine with an instruments folder)
 
 ### Geometry and timing
 

--- a/docs/library/easyrpg.md
+++ b/docs/library/easyrpg.md
@@ -31,7 +31,7 @@ Content that can be loaded by the EasyRPG core have the following file extension
 
 ### RTP files
 
-You must download the RTP2000 and RTP2003 from [here](https://www.rpgmakerweb.com/run-time-package). They are exe/zip files but can be extracted with e.g. 7zip. Create a `rtp` folder in the `system` folder of the frontend. Put the extracted data from the RTP2000 "rtp/2000" and the extracted data from the RTP2003 in "rtp/2003".
+You must download the RTP2000 and RTP2003 from [here](https://www.rpgmakerweb.com/run-time-package). They are exe/zip files but can be extracted with e.g. 7zip. Create a `rtp` folder in the `system` folder of the frontend. Put the extracted data from the RTP2000 in "rtp/2000" and the extracted data from the RTP2003 in "rtp/2003".
 
 |   |   |   |   |   |
 |---|---|---|---|---|


### PR DESCRIPTION
- Mention that lzh files can be opened (recent feature, already set as valid in the libretro info file)
- Clarify that the RTPs must be placed in the system folder set for libretro and not a hardcoded system folder
- Mention that games can write in arbitrary files from the directory of the game (feature that can be used by some games to e.g. write data in txt files)
- Add info on where Soundfont, Font and WildMidi are to be placed in the frontend's system directory