### PR TITLE
Fix WildMidi location for the EasyRPG core

### DIFF
--- a/docs/library/easyrpg.md
+++ b/docs/library/easyrpg.md
@@ -95,7 +95,7 @@ The EasyRPG core saves/loads to/from these directories.
 - easyrpg-player/config.ini (configuration of the engine)
 - easyrpg-player/Soundfont (soundfont files)
 - easyrpg-player/Font (font files)
-- easyrpg-player/wildmidi.cfg (wildmidi configuration file, to combine with an instruments folder)
+- wildmidi.cfg (wildmidi configuration file, to combine with an instruments folder)
 
 ### Geometry and timing
 


### PR DESCRIPTION
Got carried away when writing down the system location section, and forgot that WildMidi is not to be placed in the easyrpg-player folder, my apologies.