### PR TITLE
Fix licenses

### DIFF
--- a/docs/development/licenses.md
+++ b/docs/development/licenses.md
@@ -101,7 +101,7 @@ See below for a summary of the licenses behind RetroArch and its cores:
 | Dungeon Crawl Stone Soup                                                         | [GPLv2+](https://github.com/libretro/crawl-ref/blob/master/crawl-ref/licence.txt)         |                |
 | EasyRPG                                                                          | [GPLv3](https://github.com/libretro/easyrpg-libretro/blob/master/COPYING)                 |                |
 | [EightyOne](../library/eightyone.md)             			           | [GPLv3](https://github.com/libretro/81-libretro/blob/master/LICENSE)                      |                |
-| [Elektronika - BK-0010/BK-0011](../library/bk.md)                                          | [BSD](https://github.com/libretro/bk-emulator/blob/master/COPYING) |                            |
+| [Elektronika - BK-0010/BK-0011](../library/bk.md)                                          | [HPND](https://github.com/libretro/bk-emulator/blob/master/COPYING) |                            |
 | [EmuSCV](../library/emuscv.md)                           | [GPLv2](https://github.com/libretro/)                  |                |
 | [Emux CHIP-8](../library/emux_chip8.md)                                          | [GPLv2](https://github.com/libretro/emux/blob/master/COPYING)                             |                |
 | [Emux GB](../library/emux_gb.md)                                                 | [GPLv2](https://github.com/libretro/emux/blob/master/COPYING)                             |                |
@@ -118,7 +118,7 @@ See below for a summary of the licenses behind RetroArch and its cores:
 | [FFmpeg](../library/ffmpeg.md)                                                   | [LGPLv2, GPLv2](https://github.com/libretro/FFmpeg/blob/master/LICENSE.md)                |                |
 | [Flycast](../library/flycast.md)                                                 | [GPLv2](https://github.com/libretro/flycast/blob/master/LICENSE)        |                |
 | fMSX                                                                             | [Non-commercial](https://github.com/libretro/fmsx-libretro/blob/master/LICENSE)           | Non-commercial |
-| FreeIntv                                                                         | [GPLv3](https://github.com/libretro/FreeIntv/blob/master/LICENSE)             |                |
+| FreeIntv                                                                         | [GPLv2+](https://github.com/libretro/FreeIntv/blob/master/LICENSE)             |                |
 | FreeJ2ME                                                                         | [GPLv3](https://github.com/hex007/freej2me/blob/master/LICENSE)                           |                |
 | Frodo                                                                            | [GPLv2](https://github.com/r-type/frodo-libretro/blob/master/COPYING)                     |                |
 | Fuse                                                                             | [GPLv3](https://github.com/libretro/fuse-libretro/blob/master/LICENSE)                    |                |

--- a/docs/library/bk.md
+++ b/docs/library/bk.md
@@ -34,7 +34,7 @@ The bk core has been authored by
 
 The bk core is licensed under
 
-- [BSD](https://github.com/libretro/bk-emulator/blob/master/COPYING)
+- [HPND](https://github.com/libretro/bk-emulator/blob/master/COPYING)
 
 A summary of the licenses behind RetroArch and its cores can be found [here](../development/licenses.md).
 

--- a/docs/library/freeintv.md
+++ b/docs/library/freeintv.md
@@ -15,7 +15,7 @@ The FreeIntv core has been authored by
 
 The FreeIntv core is licensed under
 
-- [GPLv3](https://github.com/libretro/FreeIntv/blob/master/LICENSE)
+- [GPLv2+](https://github.com/libretro/FreeIntv/blob/master/LICENSE)
 
 A summary of the licenses behind RetroArch and its cores can be found [here](../development/licenses.md).
 


### PR DESCRIPTION
### Description
This PR corrects the license in the `.md` files for the **bk** and **FreeIntv** cores to accurately reflect their actual licenses.

### Changes
* **bk.md**: Updated license from `BSD` to `HPND`.
  * *Note:* The [current license text](https://github.com/libretro/bk-emulator/blob/master/COPYING) perfectly matches the **[HPND](https://spdx.org/licenses/HPND.html)** (Historical Permission Notice and Disclaimer) terms. While it might be replaced by other compatible licenses in the future, **HPND** is the most accurate representation of the current state.
* **freeintv.md**: Updated [license](https://github.com/libretro/FreeIntv/blob/master/LICENSE) from `GPLv3` to `GPLv2+`.

These metadata corrections ensure proper licensing compliance and correct display within RetroArch.
