### PR TITLE
Add SPMP8000Emu core documentation

### DIFF
--- a/docs/development/licenses.md
+++ b/docs/development/licenses.md
@@ -169,6 +169,7 @@ See below for a summary of the licenses behind RetroArch and its cores:
 | Mupen64Plus                                               		           | [GPLv3](https://github.com/libretro/mupen64plus-libretro/blob/master/LICENSE)             |                |
 | Mupen64Plus GLES3                                         		           | [GPLv3](https://github.com/libretro/mupen64plus-libretro/blob/master/LICENSE)             |                |
 | [Native32Emu](../library/native32emu.md)                                         | [BSD-3-Clause](https://github.com/jiangxincode/Native32Emu/blob/master/LICENSE)           |                |
+| [SPMP8000Emu](../library/spmp8000emu.md)                                         | [BSD-3-Clause](https://github.com/jiangxincode/SPMP8000Emu/blob/master/LICENSE)           |                |
 | Neko Project II                                           		           |                                                                                           |                |
 | Neko Project II Kai                                                              | [MIT](https://github.com/AZO234/NP2kai/blob/master/LICENSE)                               |                |
 | [Nestopia](../library/nestopia.md)                                               | [GPLv2](https://github.com/libretro/nestopia/blob/master/COPYING)                         |                |

--- a/docs/development/licenses.md
+++ b/docs/development/licenses.md
@@ -41,6 +41,7 @@ See below for a summary of the licenses behind RetroArch and its cores:
 | [Snes9x 2005](../library/snes9x_2005.md)                                         | [Non-commercial](https://github.com/libretro/snes9x/blob/master/docs/snes9x-license.txt)  | Non-commercial |
 | [Snes9x 2005 Plus](../library/snes9x_2005_plus.md)                               | [Non-commercial](https://github.com/libretro/snes9x/blob/master/docs/snes9x-license.txt)  | Non-commercial |
 | [Snes9x 2010](../library/snes9x_2010.md)                                         | [Non-commercial](https://github.com/libretro/snes9x2010/blob/master/LICENSE.txt) | Non-commercial |
+| [SPMP8000Emu](../library/spmp8000emu.md)                                         | [BSD-3-Clause](https://github.com/jiangxincode/SPMP8000Emu/blob/master/LICENSE)           |                |
 | UME 2014                                                                         | [MAME (Non-commercial)](https://github.com/libretro/mame2014-libretro/blob/master/docs/license.txt)         | Non-commercial |
 
 ## Libretro
@@ -201,12 +202,12 @@ See below for a summary of the licenses behind RetroArch and its cores:
 | [SameDuck](../library/sameduck.md)                                               | [MIT](https://github.com/libretro/) | |
 | [SAME_CDI](../library/same_cdi.md)                                               | [GPLv2](https://github.com/libretro/same_cdi/blob/master/COPYING)                            |                |
 | [ScummVM](../library/scummvm.md)                                                 | [GPLv2](https://github.com/libretro/scummvm/blob/master/COPYING)                          |                |
-| [SPMP8000Emu](../library/spmp8000emu.md)                                         | [BSD-3-Clause](https://github.com/jiangxincode/SPMP8000Emu/blob/master/LICENSE)           |                |
 | [Snes9x](../library/snes9x.md)                                                   | [Non-commercial](https://github.com/libretro/snes9x/blob/master/docs/snes9x-license.txt)  | Non-commercial |
 | [Snes9x 2002](../library/snes9x_2002.md)                                         | [Non-commercial](https://github.com/libretro/snes9x/blob/master/docs/snes9x-license.txt)  | Non-commercial |
 | [Snes9x 2005](../library/snes9x_2005.md)                                         | [Non-commercial](https://github.com/libretro/snes9x/blob/master/docs/snes9x-license.txt)  | Non-commercial |
 | [Snes9x 2005 Plus](../library/snes9x_2005_plus.md)                               | [Non-commercial](https://github.com/libretro/snes9x/blob/master/docs/snes9x-license.txt)  | Non-commercial |
 | [Snes9x 2010](../library/snes9x_2010.md)                                         | [Non-commercial](https://github.com/libretro/snes9x2010/blob/master/LICENSE.txt) | Non-commercial |
+| [SPMP8000Emu](../library/spmp8000emu.md)                                         | [BSD-3-Clause](https://github.com/jiangxincode/SPMP8000Emu/blob/master/LICENSE)           |                |
 | [Stella](../library/stella.md)                                                   | [GPLv2](https://github.com/stella-emu/stella/blob/master/License.txt)                     |                |
 | TempGBA                                                                          | [GPLv2](https://github.com/libretro/TempGBA-libretro/blob/master/copyright)               |                |
 | [TGB Dual](../library/tgb_dual.md)                                               | [GPLv2](https://github.com/libretro/tgbdual-libretro/blob/master/docs/COPYING-2.0.txt)    |                |

--- a/docs/development/licenses.md
+++ b/docs/development/licenses.md
@@ -169,7 +169,6 @@ See below for a summary of the licenses behind RetroArch and its cores:
 | Mupen64Plus                                               		           | [GPLv3](https://github.com/libretro/mupen64plus-libretro/blob/master/LICENSE)             |                |
 | Mupen64Plus GLES3                                         		           | [GPLv3](https://github.com/libretro/mupen64plus-libretro/blob/master/LICENSE)             |                |
 | [Native32Emu](../library/native32emu.md)                                         | [BSD-3-Clause](https://github.com/jiangxincode/Native32Emu/blob/master/LICENSE)           |                |
-| [SPMP8000Emu](../library/spmp8000emu.md)                                         | [BSD-3-Clause](https://github.com/jiangxincode/SPMP8000Emu/blob/master/LICENSE)           |                |
 | Neko Project II                                           		           |                                                                                           |                |
 | Neko Project II Kai                                                              | [MIT](https://github.com/AZO234/NP2kai/blob/master/LICENSE)                               |                |
 | [Nestopia](../library/nestopia.md)                                               | [GPLv2](https://github.com/libretro/nestopia/blob/master/COPYING)                         |                |
@@ -202,6 +201,7 @@ See below for a summary of the licenses behind RetroArch and its cores:
 | [SameDuck](../library/sameduck.md)                                               | [MIT](https://github.com/libretro/) | |
 | [SAME_CDI](../library/same_cdi.md)                                               | [GPLv2](https://github.com/libretro/same_cdi/blob/master/COPYING)                            |                |
 | [ScummVM](../library/scummvm.md)                                                 | [GPLv2](https://github.com/libretro/scummvm/blob/master/COPYING)                          |                |
+| [SPMP8000Emu](../library/spmp8000emu.md)                                         | [BSD-3-Clause](https://github.com/jiangxincode/SPMP8000Emu/blob/master/LICENSE)           |                |
 | [Snes9x](../library/snes9x.md)                                                   | [Non-commercial](https://github.com/libretro/snes9x/blob/master/docs/snes9x-license.txt)  | Non-commercial |
 | [Snes9x 2002](../library/snes9x_2002.md)                                         | [Non-commercial](https://github.com/libretro/snes9x/blob/master/docs/snes9x-license.txt)  | Non-commercial |
 | [Snes9x 2005](../library/snes9x_2005.md)                                         | [Non-commercial](https://github.com/libretro/snes9x/blob/master/docs/snes9x-license.txt)  | Non-commercial |

--- a/docs/guides/core-list.md
+++ b/docs/guides/core-list.md
@@ -198,6 +198,7 @@
 | SquirrelJME               | Java ME                | A port of the SquirrelJME Java ME 8 Virtual Machine emulator to libretro |
 | [Stella](https://docs.libretro.com/library/stella/)                     | Atari 2600             |                    |
 | Stella 2014               | Atari 2600             |                    |
+| [SPMP8000Emu](../library/spmp8000emu.md) | Sunplus SPMP8000 | An emulator for the Sunplus SPMP8000 game platform used by portable game devices |
 | Super Bros War            | Game engine            | A fork of Super Mario War, a fan-made multiplayer Super Mario Bros. style deathmatch game |
 | SwanStation               | Sony PlayStation       | SwanStation is a fork of the DuckStation emulator |
 | [TempGBA](https://docs.libretro.com/library/tempgba/)   | Game Boy Advance       |                    |

--- a/docs/guides/core-list.md
+++ b/docs/guides/core-list.md
@@ -195,10 +195,10 @@
 | [Snes9x 2005](https://docs.libretro.com/library/snes9x_2005/)           | Nintendo SNES/SFC      |                    |
 | [Snes9x 2005 Plus](https://docs.libretro.com/library/snes9x_2005_plus/) | Nintendo SNES/SFC      |                    |
 | [Snes9x 2010](https://docs.libretro.com/library/snes9x_2010/)           | Nintendo SNES/SFC      |                    |
+| [SPMP8000Emu](../library/spmp8000emu.md) | Sunplus SPMP8000 | An emulator for the Sunplus SPMP8000 game platform used by portable game devices |
 | SquirrelJME               | Java ME                | A port of the SquirrelJME Java ME 8 Virtual Machine emulator to libretro |
 | [Stella](https://docs.libretro.com/library/stella/)                     | Atari 2600             |                    |
 | Stella 2014               | Atari 2600             |                    |
-| [SPMP8000Emu](../library/spmp8000emu.md) | Sunplus SPMP8000 | An emulator for the Sunplus SPMP8000 game platform used by portable game devices |
 | Super Bros War            | Game engine            | A fork of Super Mario War, a fan-made multiplayer Super Mario Bros. style deathmatch game |
 | SwanStation               | Sony PlayStation       | SwanStation is a fork of the DuckStation emulator |
 | [TempGBA](https://docs.libretro.com/library/tempgba/)   | Game Boy Advance       |                    |

--- a/docs/guides/core-list.md
+++ b/docs/guides/core-list.md
@@ -147,7 +147,6 @@
 | [Mupen64Plus-Next GLES2](https://docs.libretro.com/library/mupen64plus/)    | Nintendo 64            |                    |
 | [Mupen64Plus-Next GLES3](https://docs.libretro.com/library/mupen64plus/)    | Nintendo 64            |                    |
 | [Native32Emu](../library/native32emu.md) | Sunplus Native32 | An emulator for the Sunplus Native32 game format used by DVD player and TV chipsets |
-| [SPMP8000Emu](../library/spmp8000emu.md) | Sunplus SPMP8000 | An emulator for the Sunplus SPMP8000 game platform used by portable game devices |
 | Neko Project II           | NEC PC-98              |                    |
 | Neko Project II Kai       | NEC PC-98              |                    |
 | NeoCD                     | Neo Geo CD             |                    |

--- a/docs/guides/core-list.md
+++ b/docs/guides/core-list.md
@@ -147,6 +147,7 @@
 | [Mupen64Plus-Next GLES2](https://docs.libretro.com/library/mupen64plus/)    | Nintendo 64            |                    |
 | [Mupen64Plus-Next GLES3](https://docs.libretro.com/library/mupen64plus/)    | Nintendo 64            |                    |
 | [Native32Emu](../library/native32emu.md) | Sunplus Native32 | An emulator for the Sunplus Native32 game format used by DVD player and TV chipsets |
+| [SPMP8000Emu](../library/spmp8000emu.md) | Sunplus SPMP8000 | An emulator for the Sunplus SPMP8000 game platform used by portable game devices |
 | Neko Project II           | NEC PC-98              |                    |
 | Neko Project II Kai       | NEC PC-98              |                    |
 | NeoCD                     | Neo Geo CD             |                    |

--- a/docs/library/spmp8000emu.md
+++ b/docs/library/spmp8000emu.md
@@ -1,0 +1,92 @@
+# SPMP8000 (SPMP8000Emu)
+
+## Background
+
+SPMP8000 is a game platform developed by Sunplus for portable game devices. The SPMP8000 chipset features an ARM-based SoC with integrated graphics, audio, and input handling. SPMP8000Emu is an emulator for this platform written in Rust, with a libretro core front-end.
+
+The SPMP8000Emu core has been authored by:
+
+- jiangxincode
+
+The SPMP8000Emu core is licensed under:
+
+- [BSD-3-Clause](https://github.com/jiangxincode/SPMP8000Emu/blob/master/LICENSE)
+
+A summary of the licenses behind RetroArch and its cores can be found [here](../development/licenses.md).
+
+## BIOS
+
+No BIOS or firmware files are required.
+
+## Extensions
+
+Content that can be loaded by the SPMP8000Emu core have the following file extensions:
+
+- .bin
+
+RetroArch database(s) that are associated with the SPMP8000Emu core:
+
+- SPMP8000
+
+## Features
+
+Frontend-level settings or features that the SPMP8000Emu core respects:
+
+| Feature           | Supported |
+|-------------------|:---------:|
+| Restart           | ✔         |
+| Saves             | ✕         |
+| States            | ✕         |
+| Rewind            | ✕         |
+| Netplay           | ✕         |
+| Core Options      | ✕         |
+| [Memory Monitoring (achievements)](../guides/memorymonitoring.md) | ✕         |
+| RetroArch Cheats  | ✕         |
+| Native Cheats     | ✕         |
+| Controls          | ✔         |
+| Remapping         | ✔         |
+| Multi-Mouse       | ✕         |
+| Rumble            | ✕         |
+| Sensors           | ✕         |
+| Camera            | ✕         |
+| Location          | ✕         |
+| Subsystem         | ✕         |
+| [Softpatching](../guides/softpatching.md) | ✕         |
+| Disk Control      | ✕         |
+| Username          | ✕         |
+| Language          | ✕         |
+| Crop Overscan     | ✕         |
+| LEDs              | ✕         |
+
+## Directories
+
+The SPMP8000Emu core's library name is 'SPMP8000 (SPMP8000Emu)'
+
+## Usage
+
+The SPMP8000Emu core loads .bin game ROMs directly. Video is output in the XRGB8888 pixel format and audio is output as stereo. Save states, cheats, and core options are not yet implemented.
+
+## User 1 device types
+
+The SPMP8000Emu core supports the following device type(s) in the controls menu, bolded device types are the default for the specified user(s):
+
+- **RetroPad** - Gamepad
+
+## Joypad
+
+| RetroPad Inputs                                | User 1 input descriptors |
+|------------------------------------------------|--------------------------|
+| ![](../image/retropad/retro_b.png)             | O Button                 |
+| ![](../image/retropad/retro_a.png)             | X Button                 |
+| ![](../image/retropad/retro_start.png)         | START                    |
+| ![](../image/retropad/retro_select.png)        | SELECT                   |
+| ![](../image/retropad/retro_dpad_up.png)       | Up                       |
+| ![](../image/retropad/retro_dpad_down.png)     | Down                     |
+| ![](../image/retropad/retro_dpad_left.png)     | Left                     |
+| ![](../image/retropad/retro_dpad_right.png)    | Right                    |
+
+## External links
+
+- [SPMP8000Emu Repository](https://github.com/jiangxincode/SPMP8000Emu)
+- [Libretro SPMP8000Emu Core info file](https://github.com/libretro/libretro-super/blob/master/dist/info/spmp8000emu_libretro.info)
+- [Report Libretro SPMP8000Emu Core Issues Here](https://github.com/jiangxincode/SPMP8000Emu/issues)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -281,6 +281,7 @@ nav:
         - 'MSX/SVI/ColecoVision/SG-1000 (blueMSX)': 'library/bluemsx.md'
       - 'Sunplus Emulation':
         - 'Sunplus - Native32 (Native32Emu)': 'library/native32emu.md'
+        - 'Sunplus - SPMP8000 (SPMP8000Emu)': 'library/spmp8000emu.md'
       - 'Texas Instruments Emulation':
         - 'Texas Instruments - TI-83 (Numero)': 'library/numero.md'
       - 'Thomson Emulation':


### PR DESCRIPTION
Add documentation for the SPMP8000Emu libretro core, following the [adding a new core](https://github.com/libretro/docs#adding-a-new-core) instructions.

SPMP8000Emu emulates the SPMP8000 game platform developed by Sunplus for portable game devices. The core supports `.bin` ROMs. The core is written in Rust and licensed BSD-3-Clause.

- Core source: https://github.com/jiangxincode/SPMP8000Emu
- Core info file PR (libretro-super): https://github.com/libretro/libretro-super/pull/2022

## Changes

Per the new-core checklist:

- **Added** `docs/library/spmp8000emu.md` — the core documentation page, based on `docs/meta/core-template.md` (background, license, extensions, features table, controls, usage, external links).
- **Updated** `mkdocs.yml` — added a "Sunplus Emulation" entry for SPMP8000Emu pointing to the new page.
- **Updated** `docs/guides/core-list.md` — added the SPMP8000Emu row (alphabetically under S, after Native32Emu).
- **Updated** `docs/development/licenses.md` — added the SPMP8000Emu entry (BSD-3-Clause) in the Cores table.

## Notes

The checklist items that don't apply were skipped:
- No BIOS/firmware required, so no `docs/library/bios.md` entry.
- No softpatching support, so no `docs/guides/softpatching.md` entry.
- No RetroAchievements support, so no `docs/guides/retroachievements.md` entry.

Several features (save states, cheats, core options) are still in progress; the features table reflects the current state.