### PR TITLE
Update typos-action

### DIFF
--- a/.github/workflows/typos.yml
+++ b/.github/workflows/typos.yml
@@ -15,6 +15,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Actions Repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
     - name: Spell Check Repo
-      uses: crate-ci/typos@v1.30.2
+      uses: crate-ci/typos@v1.48.0

--- a/_typos.toml
+++ b/_typos.toml
@@ -6,31 +6,36 @@ extend-exclude = [
 
 # Match Inside a Word - Case Insensitive
 [default.extend-words]
-ue = "ue"          # Nestopia UE
-sav = "sav"        # .sav file extension
-kernal = "kernal"  # Commodore's low-level Operating System
-gam = "gam"        # GAM4980 core name / .gam file extension
-bload = "bload"    # MSX-BASIC BLOAD command (library/bluemsx.md)
-consol = "consol"  # Atari 8-bit CONSOL_SELECT/CONSOL_START hardware register (library/atari800.md)
-pn = "pn"          # UPnP substring (ppsspp.md, netplay-faq.md, netplay-getting-started.md)
-lod = "lod"        # GLSL textureLodOffset substring (development/shader/slang-shaders.md)
-accomodate = "accomodate"  # ACCOMODATE_POSSIBLE_DYNAMIC_LOOPS, a real CRT-Royale shader macro (shader/crt_royale.md)
-betwee = "betwee"    # betwee.mp3, a real 8.3-truncated PrBoom DOS asset filename (library/prboom.md)
-messag = "messag"    # messag.mp3, ditto
-openin = "openin"    # openin.mp3, ditto
-runnin = "runnin"    # runnin.mp3, ditto
-bumpter = "bumpter"  # Vita_Bumpter_Left.png, a real Button_Pack asset filename
-outter = "outter"    # Remote_Circle_Outter.png, ditto
-tilda = "tilda"      # Keyboard_*_Tilda.png, ditto
-sentris = "sentris"  # Sentris, a real game title (image/Button_Pack/Readme.txt)
-cruzes = "cruzes"    # Cruzes, a real (stub) core entry (guides/core-list.md)
-ment = "ment"        # part of "Greg DeMent", a real person's surname (library/prosystem.md)
-nd = "nd"            # part of "Button 2ND" (library/numero.md)
-som = "som"          # som_msu1.sfc, a real filename (library/snes9x.md)
-hsi = "hsi"          # .hsi file extension (guides/softwarelist-getting-started.md)
-discernable = "discernable"  # a widely-accepted alternate spelling of "discernible" (guides/rgui.md)
-alis = "alis"        # KEY_ALIS, an example keytool placeholder (development/retroarch/compilation/android.md)
-ba = "ba"            # part of the "ba4980-c-sdk" tool-repo URL slug (library/gam4980.md)
-thq = "thq"          # THQ, a real video game publisher (library/compatibility/gba.md)
-mis = "mis"          # part of the valid "mis-matched" hyphenation (guides/softwarelist-getting-started.md)
+ue = "ue"                      # Nestopia UE
+sav = "sav"                    # SAV file extension
+kernal = "kernal"              # Commodore's low-level Operating System
+gam = "gam"                    # GAM4980 core name / GAM file extension
+bumpter = "bumpter"            # Vita_Bumpter_Left.png, a real Button_Pack asset filename
+outter = "outter"              # Remote_Circle_Outter.png, ditto
+tilda = "tilda"                # Keyboard_*_Tilda.png, ditto
+cruzes = "cruzes"              # Cruzes, a real (stub) core entry (guides/core-list.md)
+ment = "ment"                  # part of "Greg DeMent", a real person's surname (library/prosystem.md)
+hsi = "hsi"                    # HSI file extension (guides/softwarelist-getting-started.md)
+discernable = "discernable"    # a widely-accepted alternate spelling of "discernible" (guides/rgui.md)
+mis = "mis"                    # part of the valid "mis-matched" hyphenation (guides/softwarelist-getting-started.md)
 informations = "informations"  # only remaining match is the quick-informations.md FILENAME itself (kept as-is: many other pages link to it by this exact path); every genuine prose occurrence of this typo was fixed
+rewinded = "rewinded"          # Technical term for rewinding process
+
+# Regex patterns for identifiers
+[default]
+extend-ignore-re = [
+  "\\b(?:betwee|messag|openin|runnin)\\.mp3\\b",  # A real 8.3-truncated PrBoom DOS asset filenames
+  "2ND",                       # Button 2ND (library/numero.md)
+  "ACCOMODATE_",               # A real CRT-Royale shader macro (shader/crt_royale.md)
+  "ba4980-c-sdk",              # Minimal C language development kit for BuBuGao (BBK) A-series electronic dictionaries
+  "BLOAD",                     # MSX-BASIC BLOAD command
+  "CONSOL_(SELECT|START)",     # Atari 8-bit CONSOL_SELECT/CONSOL_START hardware register
+  "KEY_ALIS",                  # Example keytool placeholder
+  "Sentris",                   # A real game title (image/Button_Pack/Readme.txt)
+  "som_msu1.sfc",              # A real filename (library/snes9x.md)
+  "textureLodOffset",          # GLSL textureLodOffset substring
+  "THQ",                       # THQ, a real video game publisher
+  "UPnP",                      # Universal Plug and Play
+  "Virtua Gun",                # Official light-gun peripheral for the Sega Saturn.
+  "Virtua Racing Deluxe",      # Formula One racing video game
+]

--- a/docs/guides/change-directories.md
+++ b/docs/guides/change-directories.md
@@ -33,7 +33,7 @@ Table of special values limited to some variables:
 
 ## Cores
 
-This is the location for all your cores. To [install them using the user interface](download-cores.md#installing-cores-through-retroarch-interface), this setting needs to point to a writeable directory.
+This is the location for all your cores. To [install them using the user interface](download-cores.md#installing-cores-through-retroarch-interface), this setting needs to point to a writable directory.
 
 !!! note
     The Ubuntu PPA does not point this to a user-writable directory because cores are modified by the package manager. If you want to change it manually, you might want to change this directory from "retroarch.cfg" with a text editor since the RetroArch file browser doesn't show hidden folders by default. *libretro_directory =* is what you need to change in the config file. Some distributions use `~/.config/retroarch/cores/`

--- a/docs/guides/install-steamlink.md
+++ b/docs/guides/install-steamlink.md
@@ -73,7 +73,7 @@ Find out the IP address that SteamLink receives, which you can learn from your r
 
 FileZilla
 
-| Host  | Username  | Passoword  | Port  |
+| Host  | Username  | Password  | Port  |
 |---|---|---|---|
 | 192.168.1.5  | root  |  steamlink123 | 22  |
 

--- a/docs/guides/softwarelist-getting-started.md
+++ b/docs/guides/softwarelist-getting-started.md
@@ -35,27 +35,27 @@ Multi (MESS 2016) is a snapshot of the MESS project from v0.160. The MESS projec
 UME cores are no longer in RetroArch. Multi (UME 2015) was a snapshot of the Universal Machine Emulator. This was a precursor to the MAME/MESS merger, released by David Haywood (haze). The MAME and MESS project codebases co-existed in the MESS SVN development tree before they officially merged. This allowed haze to build and release the emulator with unmodified code from both projects under the name UME.
 
 ## Use the correct version of romset for the desired emulator
-  
+
 Arcade (MAME) will be the focus of this guide, but also the old Arcade (MAME 2016), the MULTI (MESS 2015) and MULTI (UME 2015) cores had this ability (so this information is also provided for documentation purposes). As in MAME arcade emulation, each core requires its own distinct version of software list "romsets", which the emulator supports.
 
 | Emulator | Required ROM Version | Notes |
 | :---: | :---: | :---: |
 | MAME (latest version) | MAME (latest version) | or same version if not in sync with MAME upstream |
-| MAME 2016 | MAME 0.174 | RetroArch core no longer provided | 
+| MAME 2016 | MAME 0.174 | RetroArch core no longer provided |
 | MESS 2015 | MAME 0.160 | RetroArch core no longer provided |
 | UME 2015 | MAME 0.160 | RetroArch core no longer provided |
 
 !!! tip
     For best results, start with a full software list ROM collection with a version that matches the emulator you are using. Individual romset zip files may not include BIOS ROMs, "Parent" romsets, necessary audio sample files, etc.
     Matching emulator and game versions is advised for maximum compatibility, but you may find mis-matched combinations also work.
-    
+
 ---
 
 ## Running software list machines
 There are two ways of configuring Retroarch to launch software list machines and games with MAME cores.
 
   1. **Method 1 - MAME Frontend direct launch:** uses the inbuilt MAME logic and hash files to launch your games
-  2. **Method - RetroArch fontend friendly via Libretro CMD file launch:** uses an extra libretro feature to pass command line functions to the core 
+  2. **Method - RetroArch frontend friendly via Libretro CMD file launch:** uses an extra libretro feature to pass command line functions to the core
 
 ### Method 1: MAME Frontend direct launch
 
@@ -94,7 +94,7 @@ Place any .zip games and .zip bios files required here:
 "YourPath"/Games/Atari 7800/a7800/asteroid.zip
 
 !!! note
-    To place the bios file above a7800 is the way that official MAME stores the data and thus also recommended here. You could also put the bios into the a7800 folder, but that's not how official MAME does it. 
+    To place the bios file above a7800 is the way that official MAME stores the data and thus also recommended here. You could also put the bios into the a7800 folder, but that's not how official MAME does it.
 
 You may also put or even extract the bios file to their own folder within the games directory
 "YourPath"/Games/Atari 7800/a7800/a7800/7800.rom
@@ -103,7 +103,7 @@ Now launch the game: In RetroArch, choose "Load Content" and browse to asteroid.
 
 (To Do: Add note about SoftList xml specifying the game names and crc and only supporting only those specific file names. Dummy files for CD-based games.)
 
-### Method 2: RetroArch frontend friendly via Libretro CMD file launching  
+### Method 2: RetroArch frontend friendly via Libretro CMD file launching
 
 This method follows the same folder structure as above, but you can use custom naming outside of the hash file included with MAME. It utilises some custom additions to the Libretro MAME Cores. Specifically the use of text files (.cmd) to replicate sending command line actions as you can with mainline MAME.
 
@@ -117,4 +117,3 @@ To do: Other path definitions, e.g. under Windows? Maybe explain the different s
 Now launch the game: In RetroArch, choose "Load Content" and browse to asteroid.cmd, and it should launch with MAME current.
 
 To do: Cmd file example
-

--- a/docs/library/fbneo.md
+++ b/docs/library/fbneo.md
@@ -34,7 +34,7 @@ There are controversies about whether libretro's patreon and retroarch's GPL lic
 
 * **"Redistributions may not be sold, nor may they be used in a commercial product or activity."** : By definition, a commercial activity is an activity involving the sale of goods or services. The libretro project does none of that, and it is unclear whether a patreon should be treated as a commercial activity or not when no goods or services are provided in exchange of the donations.
 * **"You may not ask for donations to support your work on any project that uses the FB Neo source code."** : This FBNeo port is using libretro code, not the other way around. This port is directly authored/maintained/supported by members of the FBNeo team, and none of them is receiving donations. Interestingly, if receiving donations was de facto a commercial activity, this term shouldn't be required.
-* *If* the libretro project was a commercial activity, it would still be unclear how it does affect this port. Our win32 standalone builds use the directx api, which belongs to a commercial company. Using the libretro api, which would belong to a commercial activity, wouldn't be any different. Furthermore, in all likeliness, there would still be alternative libretro frontends that don't belong to the libretro project and are not commercial. 
+* *If* the libretro project was a commercial activity, it would still be unclear how it does affect this port. Our win32 standalone builds use the directx api, which belongs to a commercial company. Using the libretro api, which would belong to a commercial activity, wouldn't be any different. Furthermore, in all likeliness, there would still be alternative libretro frontends that don't belong to the libretro project and are not commercial.
 * Actually, alternative commercial libretro frontends already exist, and we consider we are not concerned as long as they neither redistribute FBNeo nor use it as some mean of advertisement. In this scenario, only a manual installation of the core by the user will be considered legal and supported.
 * While GPL code can't be mixed with non-commercial code, this is a non-issue since this port doesn't contain any GPL-licensed code.
 * Under european law, where the libretro buildbots are located, linking GPL and non-commercial software doesn't produce a derivative work, and doesn't extend the GPL license to the non-commercial work (source [here](https://joinup.ec.europa.eu/collection/eupl/licence-compatibility-permissivity-reciprocity-and-interoperability)). It is unclear whether the same applies in non-EU countries or not.
@@ -285,13 +285,13 @@ Here is a list of samples currently in use :
 
 Copy [hiscore.dat](https://github.com/libretro/FBNeo/raw/master/metadata/hiscore.dat) to `SYSTEM_DIRECTORY/fbneo/` and have `Quick Menu > Core Options > Hiscores` enabled.
 
-It doesn't guarantee hiscores will work for a specific game though, sometimes a driver could just be missing the necessary support code for this feature, or `hiscore.dat` might have a missing or broken entry for that romset. You can request support in the issue tracker. 
+It doesn't guarantee hiscores will work for a specific game though, sometimes a driver could just be missing the necessary support code for this feature, or `hiscore.dat` might have a missing or broken entry for that romset. You can request support in the issue tracker.
 
 Runahead now works with hiscores, it'll require fairly recent version of the core AND RetroArch though (support was added after 1.10.3).
 
 ## Input lag reduction
 
-This core widely supports the RetroArch input latency reduction features, with **runahead single instance** and **preemptive frames** being the recommended methods. 
+This core widely supports the RetroArch input latency reduction features, with **runahead single instance** and **preemptive frames** being the recommended methods.
 
 Proper support for **runahead second instance** is not guaranteed because it doesn't exist in standalone FBNeo unlike the other methods.
 
@@ -349,7 +349,7 @@ Games running on already emulated arcade systems will also be tolerated, the mos
 
 A lot of romhacks are supported natively, so your romhack might already be supported under a specific romset name.
 
-For the unsupported romhacks, there are 3 methods, but those romhacks are not allowed if you intend to use RetroAchievements and must be disabled by toggling off `Quick Menu > Core Options > Allow patched romsets` : 
+For the unsupported romhacks, there are 3 methods, but those romhacks are not allowed if you intend to use RetroAchievements and must be disabled by toggling off `Quick Menu > Core Options > Allow patched romsets` :
 
 #### Using the "patched" folder
 
@@ -410,7 +410,7 @@ There are several things to know :
 
 * You need to follow the instructions about [emulating consoles](#emulating-consoles-and-computers)
 * You need a copy of the `neocdz.zip` and `neogeo.zip` bioses
-* The supported format is single file MODE1/2352 cue/bin (the format where there is one .cue file with one single .bin file). Use "CDmage" to convert your dump if needed. **It must not be compressed**
+* The supported format is single file MODE1/2352 cue/bin (the format where there is one .cue file with one single .bin file). Use "CDMage" to convert your dump if needed. **It must not be compressed**
 
 You can convert your unsupported dumps by following this tutorial :
 
@@ -451,10 +451,10 @@ Additionally :
 
 The first question you should be asking yourself is "what am i comparing this to ?", emulation is meant to be faithful to real hardware (here the original arcade board), not to some console port, remaster, other emulator, or ost.
 
-If you are comparing this to FBNeo standalone, you must be warned that the libretro port is using different default audio settings. 
+If you are comparing this to FBNeo standalone, you must be warned that the libretro port is using different default audio settings.
 By default standalone has 44100 samplerate and both interpolations off, and that's what you should set in core options if you want the same audio output.
 
-Last but not least, you might also want to make sure you are running the game at the correct speed, most crt games don't run at 60Hz and if you want the proper refresh rate to be emulated you'll need to make sure `Video Settings > Force 60Hz` isn't enabled in core options and `Settings > Video > Synchronization > Sync to Exact Content Framerate` is enabled (`vrr_runloop_enable = "true"` in `retroarch.cfg`). 
+Last but not least, you might also want to make sure you are running the game at the correct speed, most crt games don't run at 60Hz and if you want the proper refresh rate to be emulated you'll need to make sure `Video Settings > Force 60Hz` isn't enabled in core options and `Settings > Video > Synchronization > Sync to Exact Content Framerate` is enabled (`vrr_runloop_enable = "true"` in `retroarch.cfg`).
 Please note that it'll likely cause frame duping if your hardware is not compatible with VRR (Variable Refresh Rate), in which case you'll have to make a choice between animation smoothness and correct refresh rate.
 
 ### Why do i get a black screen and/or can't i change bios in neogeo games ?

--- a/docs/meta/core-template.md
+++ b/docs/meta/core-template.md
@@ -93,7 +93,7 @@ Content that can be loaded by the [Core name] core have the following file exten
 
 - .[extension]
 
-// Copy the exntension entry from the core info file and paste it here.
+// Copy the extension entry from the core info file and paste it here.
 // https://github.com/libretro/libretro-super/tree/master/dist/info)
 // Also look at the core's libretro.c/libretro.cpp file, sometimes the core info files can get out of sync
 

--- a/docs/shader/crt.md
+++ b/docs/shader/crt.md
@@ -6,7 +6,7 @@ These shaders attempt to reproduce aspects and characteristics of cathode ray tu
     + ![crt-aperture](../image/shader/crt/crt-aperture.png)
 
 ## crt-blurpi
-  * A lightweight shader designed to run full speed on Raspberry Pi hardware (hence, the name) and on low-res screens (640x480 or less). It cheats a little by rendering scanlines that match your screen resolution instead of the game resolution, to avoid painful aliasing/Moiré efects on low res screens. Comes in **sharp** and **soft** flavors; use the sharp variant when using integer scaling for best results, and the soft variant otherwise.
+  * A lightweight shader designed to run full speed on Raspberry Pi hardware (hence, the name) and on low-res screens (640x480 or less). It cheats a little by rendering scanlines that match your screen resolution instead of the game resolution, to avoid painful aliasing/Moiré effects on low res screens. Comes in **sharp** and **soft** flavors; use the sharp variant when using integer scaling for best results, and the soft variant otherwise.
     + ![crt-caligari](../image/shader/crt/crt-blurPi.png)
 
 ## crt-caligari
@@ -51,7 +51,7 @@ These shaders attempt to reproduce aspects and characteristics of cathode ray tu
 
 ## crt-pi
   * A nice-looking shader designed to run full speed on all Raspberry Pi models at 4:3 aspect and 1080p, though RPi1 and Zero models may need overclocking to achieve this, and some settings may be too demanding on some models. Aside from RPi hardware, this is just an all-around good shader for weak/mobile GPUs.
-   
+
 
 ## crt-potato
   * An attempt to reproduce the very demanding effects of the popular Kurozumi variation of CRT-Royale through a simple lookup texture. It does not capture much of the nuances of the demanding shader it tries to copy, but it runs very fast and comes with **-Warm** and **-Cool** flavors, which describe their warmer and cooler white points, respectively.


### PR DESCRIPTION
- Bump crate-ci/typos action to v1.48.0
- Update _typos.toml to suppress remaining false positives
- Fix genuine typos found by the updated spell checker