### PR TITLE
Correct the RustyNES core license (MIT/Apache -> GPL-3.0-or-later)

### DIFF
--- a/docs/library/rustynes.md
+++ b/docs/library/rustynes.md
@@ -14,7 +14,7 @@ The RustyNES core has been authored by
 
 The RustyNES core is licensed under
 
-- MIT OR Apache-2.0
+- GPL-3.0-or-later
 
 A summary of the licenses behind RetroArch and its cores can be found [here](../development/licenses.md).
 


### PR DESCRIPTION
RustyNES relicensed from **MIT/Apache-2.0 to GPL-3.0-or-later** in its v2.2.9 release (2026-08-04). This page predates that change and still lists the old terms.

Single-line change to the Author/License section:

```diff
 The RustyNES core is licensed under

-- MIT OR Apache-2.0
+- GPL-3.0-or-later
```

The matching `dist/info` correction is [libretro-super#2069](https://github.com/libretro/libretro-super/pull/2069).

**SPDX form used here deliberately.** This page reads as prose, and the neighbouring library pages use full license names rather than the short `.info` tokens, so `GPL-3.0-or-later` fits the context. The info file uses libretro's own dialect (`GPLv3+`) for the same license.

I checked the rest of the page against the current core rather than only fixing the line I came for, and nothing else needs changing:

- **Extensions** (`.nes`, `.fds`) match the core's `retro_get_system_info` declaration.
- **Databases** and the `disksys.rom` BIOS entry (md5 `ca30b50f880eb660a320674ed365ef7a`) are unchanged and correct.
- **Features table** is accurate as written. Worth noting `Restart ✔` is *newly* true rather than newly documented — `retro_reset` was unimplemented and inherited the library's no-op default until v2.3.5, so the button did nothing before then. `Core Options ✕` remains correct; core options are still unexposed.
