### PR TITLE
fix: update vintage simulator link

### DIFF
--- a/docs/development/frontends.md
+++ b/docs/development/frontends.md
@@ -23,7 +23,7 @@ Name | Author(s) |  Description
 [Minimal reference fronted](https://github.com/bparker06/reference_frontend) | bparker06 | This is a barebones minimal reference frontend for the libretro API.
 [minir](https://github.com/Alcaro/minir) | Alcaro | WIMP interface (Windows, Icons, Menus and Pointers), and only cares about the major desktop OSes. Drops flexibility in favor of improved out-of-the-box experience.
 [minir test fronts](https://github.com/Alcaro/minir/tree/master/subproj) | Alcaro | Three different fronts, none of which has IO drivers: retroprofile just runs the core, intended for performance tests and PGO; retrorepeat runs the core twice, expecting identical output; retrostateverify traces the entire core and verifies whether its savestates are perfect.
-[miniretro](https://github.com/davidgfnet/miniretro) | davidgfnet | This is a small (Linux only for now) CLI libretro frontend for automated testing of libretro cores. 
+[miniretro](https://github.com/davidgfnet/miniretro) | davidgfnet | This is a small (Linux only for now) CLI libretro frontend for automated testing of libretro cores.
 [nanoarch](https://github.com/heuripedes/nanoarch) | heuripedes | Small frontend providing video, audio and basic input features to run non-libretro-GL cores. Built on GLFW.
 [New Retro Arcade](http://digitalcybercherries.com/) | Digital Cyber Cherries | |
 [noarch](https://github.com/robloach/noarch) | RobLoach | Minimalist frontend which does not provide video, audio or even basic input. It loads a libretro core, runs an iteration, and then exits. Good for unit testing.
@@ -37,5 +37,5 @@ Name | Author(s) |  Description
 [RetroPlayer](https://forum.kodi.tv/forumdisplay.php?fid=194) | Kodi-Game | Also known as [Kodi-Game](https://github.com/kodi-game/), RetroPlayer is a libretro compatibility layer for [Kodi](https://kodi.tv/).
 [sdlarch](https://github.com/heuripedes/sdlarch) | heuripedes | Small frontend providing video, audio and basic input to run basic libretro cores. Built on SDL.
 [URetro](https://github.com/QuarkTheAwesome/URetro) | | Nintendo WiiU frontend
-[Vintage Simulator](https://vintagesimulator.com) | runvnc | 3D Lua-programmable libretro frontend supporting many 3D formats, some Cairo graphics, physics, emulation control with scripts
+[Vintage Simulator](https://github.com/runvnc/VSIMdocs) | runvnc | 3D Lua-programmable libretro frontend supporting many 3D formats, some Cairo graphics, physics, emulation control with scripts
 [ZMZ](https://github.com/Alcaro/ZMZ) | Alcaro | Abandoned | Fork of [ZSNES](http://www.zsnes.com/) that rips out its emulation code, using libretro instead. Due to ZSNES being inflexible, ZMZ became quite a bit of a mess.

--- a/docs/development/frontends.md
+++ b/docs/development/frontends.md
@@ -37,5 +37,5 @@ Name | Author(s) |  Description
 [RetroPlayer](https://forum.kodi.tv/forumdisplay.php?fid=194) | Kodi-Game | Also known as [Kodi-Game](https://github.com/kodi-game/), RetroPlayer is a libretro compatibility layer for [Kodi](https://kodi.tv/).
 [sdlarch](https://github.com/heuripedes/sdlarch) | heuripedes | Small frontend providing video, audio and basic input to run basic libretro cores. Built on SDL.
 [URetro](https://github.com/QuarkTheAwesome/URetro) | | Nintendo WiiU frontend
-[Vintage Simulator](https://github.com/runvnc/VSIMdocs) | runvnc | 3D Lua-programmable libretro frontend supporting many 3D formats, some Cairo graphics, physics, emulation control with scripts
+[Vintage Simulator](https://github.com/runvnc/vintagesimulator.com) | runvnc | 3D Lua-programmable libretro frontend supporting many 3D formats, some Cairo graphics, physics, emulation control with scripts
 [ZMZ](https://github.com/Alcaro/ZMZ) | Alcaro | Abandoned | Fork of [ZSNES](http://www.zsnes.com/) that rips out its emulation code, using libretro instead. Due to ZSNES being inflexible, ZMZ became quite a bit of a mess.


### PR DESCRIPTION
This is a very nice clean update that updates the hyperlink to the right location.  



Closes #1111 