### PR TITLE
Add WQXEmu core documentation

### DIFF
--- a/docs/development/licenses.md
+++ b/docs/development/licenses.md
@@ -233,6 +233,7 @@ See below for a summary of the licenses behind RetroArch and its cores:
 | [Vircon32](../library/vircon32.md)                                   | [BSD-3-Clause](https://github.com/vircon32/vircon32-libretro/blob/main/LICENSE.md)        |                |
 | [Virtual Jaguar](../library/virtual_jaguar.md)                                   | [GPLv3](https://github.com/libretro/virtualjaguar-libretro/blob/master/docs/GPLv3)        |                |
 | [VirtualXT](../library/virtualxt.md)                                   | [zlib](https://github.com/andreas-jonsson/virtualxt/blob/develop/LICENSE)        |                |
+| [WQXEmu](../library/wqxemu.md)                                                     | [GPLv3+](https://github.com/AloysHF/WQXEmu/blob/master/LICENSE)                 |                |
 | [XRick](../library/xrick.md)                                                     | [GPLv3](https://github.com/libretro/xrick-libretro/blob/master/README)                    |                |
 | [YabaSanshiro](../library/yabasanshiro.md)						   | [GPLv2](https://github.com/libretro/yabasanshiro/blob/master/yabause/COPYING)                  |                |
 | [Yabause](../library/yabause.md)						   | [GPLv2](https://github.com/libretro/yabause/blob/master/yabause/COPYING)                  |                |

--- a/docs/guides/core-list.md
+++ b/docs/guides/core-list.md
@@ -237,6 +237,7 @@
 | vitaQuake 2 (Zaero)       | Game engine            | (See vitaQuake 2 note) |
 | vitaQuake 3               | Game engine            | A port of the VitaQuake 3 source port of iD's ioquake3 engine to libretro |
 | vitaVoyager               | Game engine            | A port of the Lilium Voyager engine, which runs the Star Trek: Voyager - Elite Force game and is itself based on the ioquake3 |
+| [WQXEmu](../library/wqxemu.md) | Wenquxing Electronic Dictionary | Emulates NC1020, PC1000, CC800, NC2000, and NC3000 models via low-level firmware execution |
 | WASM-4                    | Game engine            | WASM-4 is a open source low-level fantasy game console for building small games with WebAssembly |
 | X Millennium              | Sharp X1               |                    |
 | XRick                     | Game engine            | A port of the XRick, an open-source clone of the Rick Dangerous engine |

--- a/docs/library/wqxemu.md
+++ b/docs/library/wqxemu.md
@@ -1,0 +1,104 @@
+# Wenquxing (WQXEmu)
+
+## Background
+
+Wenquxing (文曲星) is a series of Chinese electronic dictionaries manufactured by BESTA. The devices use a 6502/W65C02 CPU (SPDC1024 SoC) and include built-in games and applications. WQXEmu is a low-level emulator that runs actual firmware dumped from physical devices, supporting NC1020, PC1000, CC800, NC2000, and NC3000 models.
+
+The WQXEmu core has been authored by:
+
+- Aloys
+
+The WQXEmu core is licensed under:
+
+- [GPL-3.0-or-later](https://github.com/AloysHF/WQXEmu/blob/master/LICENSE)
+
+A summary of the licenses behind RetroArch and its cores can be found [here](../development/licenses.md).
+
+## Firmware
+
+WQXEmu requires original hardware firmware files placed in RetroArch's system directory. The firmware is model-specific and conditionally required based on the selected model in Core Options.
+
+| Model | Required files |
+|-------|---------------|
+| NC1020 | `WQXEmu/nc1020/obj_lu.bin`, `WQXEmu/nc1020/nc1020.fls` |
+| PC1000 | `WQXEmu/pc1000/pc1000.rom`, `WQXEmu/pc1000/pc1000.fls` |
+| CC800 | `WQXEmu/cc800/obj.bin`, `WQXEmu/cc800/cc800.fls` |
+| NC2000 | `WQXEmu/nc2000/nc2000.nor`, `WQXEmu/nc2000/nc2000.nand`, `WQXEmu/nc2000/nc2000.nand0` |
+| NC3000 | `WQXEmu/nc3000/nc3000.nor`, `WQXEmu/nc3000/nc3000.nand` (optional: `WQXEmu/nc3000/nc3000.nand0`) |
+
+## Extensions
+
+WQXEmu does not accept content files. The core starts without content and boots the selected model's firmware directly.
+
+## Features
+
+Frontend-level settings or features that the WQXEmu core respects:
+
+| Feature           | Supported |
+|-------------------|:---------:|
+| Restart           | ✔         |
+| Saves             | ✔         |
+| States            | ✔         |
+| Rewind            | ✕         |
+| Netplay           | ✕         |
+| Core Options      | ✔         |
+| [Memory Monitoring (achievements)](../guides/memorymonitoring.md) | ✕         |
+| RetroArch Cheats  | ✕         |
+| Native Cheats     | ✕         |
+| Controls          | ✔         |
+| Remapping         | ✔         |
+| Multi-Mouse       | ✕         |
+| Rumble            | ✕         |
+| Sensors           | ✕         |
+| Camera            | ✕         |
+| Location          | ✕         |
+| Subsystem         | ✕         |
+| [Softpatching](../guides/softpatching.md) | ✕         |
+| Disk Control      | ✕         |
+| Username          | ✕         |
+| Language          | ✕         |
+| Crop Overscan     | ✕         |
+| LEDs              | ✕         |
+
+## Directories
+
+The WQXEmu core's library name is 'Wenquxing (WQXEmu)'
+
+## Usage
+
+The WQXEmu core starts without content. Select a model in **Quick Menu → Core Options → Machine Model**, then start the core. The selected model is applied when the core starts, so changing it requires closing and starting the core again.
+
+Video is output in the XRGB8888 pixel format at 160×80 pixels. Save states are supported. Persistent device state (writable flash/NAND, RAM, CPU, RTC) is saved automatically on content unload.
+
+## Core Options
+
+- **Machine Model** — Select NC1020, PC1000, CC800, NC2000, or NC3000. NC1020 is the default.
+
+## User 1 device types
+
+The WQXEmu core supports the following device type(s) in the controls menu, bolded device types are the default for the specified user(s):
+
+- **RetroPad** - Gamepad
+
+## Joypad
+
+| RetroPad Inputs                                | User 1 input descriptors |
+|------------------------------------------------|--------------------------|
+| ![](../image/retropad/retro_dpad_up.png)       | Up                       |
+| ![](../image/retropad/retro_dpad_down.png)     | Down                     |
+| ![](../image/retropad/retro_dpad_left.png)     | Left                     |
+| ![](../image/retropad/retro_dpad_right.png)    | Right                    |
+| ![](../image/retropad/retro_a.png)             | Enter                    |
+| ![](../image/retropad/retro_b.png)             | Escape                   |
+| ![](../image/retropad/retro_x.png)             | F1                       |
+| ![](../image/retropad/retro_y.png)             | F4                       |
+| ![](../image/retropad/retro_l1.png)            | Page Up                  |
+| ![](../image/retropad/retro_r1.png)            | Page Down                |
+| ![](../image/retropad/retro_select.png)        | F11                      |
+| ![](../image/retropad/retro_start.png)         | F10                      |
+
+## External links
+
+- [WQXEmu Repository](https://github.com/AloysHF/WQXEmu)
+- [Libretro WQXEmu Core info file](https://github.com/libretro/libretro-super/blob/master/dist/info/wqxemu_libretro.info)
+- [Report Libretro WQXEmu Core Issues Here](https://github.com/AloysHF/WQXEmu/issues)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -291,6 +291,8 @@ nav:
         - 'Texas Instruments - TI-83 (Numero)': 'library/numero.md'
       - 'Thomson Emulation':
         - 'Thomson - MO/TO (Theodore)': 'library/theodore.md'
+      - 'Wenquxing Emulation':
+        - 'Wenquxing - Electronic Dictionary (WQXEmu)': 'library/wqxemu.md'
       - 'MegaDuck Emulation':
         - 'Welback Holdings - Mega Duck (SameDuck)': 'library/sameduck.md'
     - 'Core Library: Game and Scripting Engines':


### PR DESCRIPTION
## Summary

Adds documentation for **WQXEmu**, a libretro core that emulates Wenquxing (文曲星) NC1020/PC1000/CC800/NC2000/NC3000 electronic dictionaries using low-level firmware execution.

- Core source: https://github.com/AloysHF/WQXEmu
- License: GPL-3.0-or-later

## Changes

- **`docs/library/wqxemu.md`** — New core documentation page with firmware setup, features, RetroPad mapping, and core options
- **`mkdocs.yml`** — Added "Wenquxing Emulation" nav entry
- **`docs/guides/core-list.md`** — Added WQXEmu row to the core list table
- **`docs/development/licenses.md`** — Added GPL-3.0-or-later entry for WQXEmu